### PR TITLE
Remove license section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Built with Go
   - [Common Issues](#common-issues)
   - [FAQ](#faq)
 - [Links & Resources](#links--resources)
-- [License](#license)
 
 ---
 
@@ -1008,24 +1007,3 @@ Periodically, you may:
 - **Issue Tracker**: [GitHub Issues](https://github.com/conneroisu/spectr/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/conneroisu/spectr/discussions)
 
----
-
-## License
-
-Copyright 2025 Conner Ohnesorge
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
----
-
-**Built with care by the Spectr community**


### PR DESCRIPTION
Removed the license section and its TOC reference as requested.