### PR TITLE
Add Nix-powered CI workflow (pending activation)

### DIFF
--- a/workflows-pending/README.md
+++ b/workflows-pending/README.md
@@ -1,0 +1,16 @@
+# Pending Workflow Files
+
+Due to GitHub App permissions restrictions, workflow files must be manually moved to `.github/workflows/`.
+
+## To activate the CI workflow:
+
+```bash
+mkdir -p .github/workflows
+mv workflows-pending/ci.yml .github/workflows/ci.yml
+git add .github/workflows/ci.yml
+git rm -r workflows-pending
+git commit -m "Activate CI workflow"
+git push
+```
+
+The CI workflow is ready to use once moved to the correct location.

--- a/workflows-pending/ci.yml
+++ b/workflows-pending/ci.yml
@@ -1,0 +1,99 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+# Cancel in-progress runs for the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: Run golangci-lint
+        run: nix develop .#ci -c golangci-lint run
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: Run tests with race detection
+        run: nix develop .#ci -c gotestsum --format testname -- -race ./... -timeout=2m
+
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: Check Go formatting (gofmt)
+        run: |
+          UNFORMATTED=$(nix develop .#ci -c gofmt -l .)
+          if [ -n "$UNFORMATTED" ]; then
+            echo "The following files are not formatted:"
+            echo "$UNFORMATTED"
+            exit 1
+          fi
+
+      - name: Check Go imports (goimports)
+        run: |
+          UNFORMATTED=$(nix develop .#ci -c sh -c 'goimports -l $(find . -name "*.go" -not -path "./vendor/*")')
+          if [ -n "$UNFORMATTED" ]; then
+            echo "The following files have unformatted imports:"
+            echo "$UNFORMATTED"
+            exit 1
+          fi
+
+      - name: Check Nix formatting (alejandra)
+        run: nix develop .#ci -c alejandra --check .


### PR DESCRIPTION
Creates a comprehensive CI workflow using devShells.ci from flake.nix. Includes linting (golangci-lint), testing (gotestsum with race detection), and format checking (Go and Nix).

Due to GitHub App permissions, the workflow file is in workflows-pending/. Move to .github/workflows/ci.yml to activate. See workflows-pending/README.md for instructions.