### PR TITLE
added add-propose-command

### DIFF
--- a/spectr/changes/add-propose-command/design.md
+++ b/spectr/changes/add-propose-command/design.md
@@ -1,0 +1,192 @@
+# Design: `spectr propose` Command
+
+## Context
+
+The `spectr propose <id>` command automates the workflow of creating a PR from a newly scaffolded change proposal. Users scaffold proposals with `spectr init` or manually, validate them with `spectr validate`, and then need to push them to a remote repository and open a PR.
+
+Currently, this requires manual git operations and platform-specific PR CLI invocations. This design automates these steps while preserving user control and providing clear error feedback.
+
+## Goals
+
+- **Primary**: Automate the branch → commit → push → PR workflow for change proposals
+- **Secondary**: Detect git hosting platform automatically to use the correct PR CLI
+- **Secondary**: Only work on uncommitted changes (proposed, not yet in version control)
+- **Secondary**: Ensure all staged files are ONLY from the target change folder
+
+## Non-Goals
+
+- Modify git configuration or user settings
+- Support multiple simultaneous branches or PRs from one proposal
+- Auto-merge or handle PR review workflows
+- Support git hosting platforms not detected (manual PR creation still available)
+
+## Decisions
+
+### 1. Uncommitted Change Requirement
+
+**Decision**: The command SHALL only accept change proposals that are NOT currently committed to any branch.
+
+**Rationale**:
+- The purpose is to help users create PRs for NEW proposals during active development
+- If a proposal is already committed to a branch, users can use standard git/gh/glab/tea workflows
+- This prevents accidental duplicate branches or PRs
+
+**Implementation**:
+- Use `git ls-files` to check if `spectr/changes/<id>/` is tracked
+- If tracked, return an error with guidance to commit and PR the existing branch instead
+
+### 2. Git Platform Detection
+
+**Decision**: Auto-detect the git hosting platform from the `origin` remote URL.
+
+**Detection Logic**:
+```
+github.com → GitHub (use `gh`)
+gitlab.com → GitLab (use `glab`)
+gitea/forgejo in URL → Gitea (use `tea`)
+```
+
+**Rationale**:
+- Most developers use one platform per repository
+- Parsing `git config --get remote.origin.url` is reliable and requires no external dependencies
+- Supports both HTTPS and SSH URLs
+- Gracefully handles self-hosted GitLab, Gitea, and Forgejo instances
+
+**Fallback**: If no platform is detected, return an error with the detected remote URL and ask user to run `gh pr create`, `glab mr create`, or `tea pr create` manually.
+
+### 3. Branch Naming Convention
+
+**Decision**: Create branch with name `add-<change-id>`.
+
+**Rationale**:
+- Consistent with Spectr change ID convention (verb-led, kebab-case)
+- Clearly indicates the branch purpose (adding a proposal)
+- Unlikely to conflict with existing branches
+- PR titles will reference the change ID, making history clear
+
+### 4. Commit Strategy
+
+**Decision**: Stage ONLY the `spectr/changes/<id>/` folder, commit in one step.
+
+**Implementation**:
+```bash
+git checkout -b add-<id>
+git add spectr/changes/<id>/
+git commit -m "Propose: Add <change-id> change proposal
+
+This proposal introduces [brief description from proposal.md].
+
+Change-Id: <change-id>"
+```
+
+**Rationale**:
+- Isolates changes to exactly what user intended
+- If user has other uncommitted changes, they remain uncommitted
+- Commit message includes context for reviewers
+- Git trailer `Change-Id:` aids with linking tools
+
+### 5. PR Creation
+
+**Decision**: Delegate PR creation to the appropriate CLI tool with minimal options.
+
+**For GitHub** (`gh pr create`):
+```bash
+gh pr create --title "Propose: <change-id>" --body "..."
+```
+
+**For GitLab** (`glab mr create`):
+```bash
+glab mr create --title "Propose: <change-id>" --body "..."
+```
+
+**For Gitea** (`tea pr create`):
+```bash
+tea pr create --title "Propose: <change-id>" --body "..."
+```
+
+**PR Body Template**:
+- First line: purpose from `proposal.md` ("Why" section)
+- Blank line
+- "What Changes" section from `proposal.md`
+- Blank line
+- "This proposal is ready for review." (optional)
+
+**Rationale**:
+- Minimal flags reduce complexity and platform-specific branching
+- Body includes context from the proposal for reviewers
+- Each tool has its own conventions; let them handle formatting
+- User can edit the PR title/body after creation if needed
+
+### 6. Error Handling
+
+**Decision**: Fail fast with descriptive error messages at each step.
+
+**Error Cases**:
+- Change folder doesn't exist → "Change proposal '<id>' not found in spectr/changes/"
+- Change folder already tracked → "Change '<id>' is already committed. Use git/gh/glab/tea directly to create a PR."
+- Not in a git repository → "Not in a git repository. Initialize git with 'git init'."
+- Remote not found → "No 'origin' remote configured. Run 'git remote add origin <url>' first."
+- Branch creation fails → "Failed to create branch 'add-<id>': [git error]"
+- Platform not detected → "Could not detect git hosting platform. Remote URL: [url]. Please create PR manually using gh, glab, or tea."
+- PR CLI tool not installed → "[gh/glab/tea] not found. Install from [url]."
+- PR creation fails → "Failed to create PR: [tool output]"
+
+**Rationale**:
+- Users get specific guidance on what went wrong and how to fix it
+- Preserves git state on failure (branch is created but not pushed if PR fails)
+
+### 7. Cross-Platform Support
+
+**Decision**: Use Go's `exec.Command` to invoke git and PR CLI tools; ensure compatibility with Windows, macOS, and Linux.
+
+**Rationale**:
+- `exec.Command` abstracts OS-specific shell differences
+- All three platforms have git available
+- `gh`, `glab`, `tea` are cross-platform and work identically
+
+### 8. PR URL Output
+
+**Decision**: Parse the PR CLI output to extract and display the PR URL.
+
+**Rationale**:
+- Provides immediate feedback to the user
+- Can be piped or captured for automation
+- Each tool outputs the URL in a different format; parsing handles this
+
+## Alternatives Considered
+
+### Alternative 1: Require user to provide PR title/body
+**Rejected**: Too verbose for typical case; users can edit PR after creation.
+
+### Alternative 2: Support any branch name (flag for custom branch)
+**Rejected**: Adds complexity; `add-<id>` is sufficient and clear.
+
+### Alternative 3: Push to tracking branch automatically
+**Rejected**: Requires `--set-upstream` logic; current approach delegates to the PR CLI tools which handle this.
+
+### Alternative 4: Validate the proposal before creating PR
+**Rejected**: User already ran `spectr validate`; redundant here. If needed, they can run it again.
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Git operation fails mid-workflow | Branch created but not pushed; user confusion | Clear error message; user can clean up or continue manually |
+| PR CLI tool not installed | Command fails | Error message with installation URL for the detected tool |
+| User has unstaged changes in the same folder | Unexpected behavior | Explicitly check if folder is uncommitted; fail with guidance |
+| PR title/body too long or invalid | PR creation fails | Use simple, guaranteed-valid format; user can edit in UI |
+| Auto-detection fails (weird URL format) | Command fails to detect platform | Graceful fallback; user manually runs correct tool |
+
+## Migration Plan
+
+This is a new feature; no migration required. Existing workflows continue to work unchanged.
+
+## Open Questions
+
+1. Should we support --dry-run flag to preview branch/commit without pushing?
+2. Should we parse proposal.md ourselves or trust the validation is done?
+3. Do we need to support custom remote names (not just "origin")?
+
+---
+
+**Decision Status**: Ready for implementation after approval.

--- a/spectr/changes/add-propose-command/proposal.md
+++ b/spectr/changes/add-propose-command/proposal.md
@@ -1,0 +1,30 @@
+# Change: Add `spectr propose` Command for Automated PR Creation
+
+## Why
+
+Creating change proposals is a core part of the Spectr workflow, but once a proposal is scaffolded and validated, users currently must manually create a git branch, commit, push, and open a PR. This multi-step process is repetitive and error-prone.
+
+A `spectr propose <id>` command would streamline this workflow by automating the entire PR creation process in a single command. It detects the git hosting platform (GitHub, GitLab, Gitea) and uses the appropriate CLI tool (`gh`, `glab`, `tea`), reducing friction and ensuring consistent PR workflows across teams.
+
+## What Changes
+
+- **NEW**: Add `spectr propose <id>` command that:
+  - Validates that `spectr/changes/<id>/` exists and is not yet committed to git
+  - Creates a new git branch named `add-<id>` from the current branch
+  - Stages only the `spectr/changes/<id>/` folder
+  - Commits with a descriptive message including the change ID
+  - Pushes the branch to the remote
+  - Detects the git hosting platform (GitHub, GitLab, Gitea)
+  - Invokes the appropriate PR CLI (`gh pr create`, `glab mr create`, `tea pr create`)
+  - Displays the PR URL on success
+  - **BREAKING**: None
+
+## Impact
+
+- **Affected specs**: `cli-interface`, `cli-framework`
+- **Affected code**:
+  - `cmd/` - Add `ProposeCmd` command handler
+  - `internal/` - New `propose` package with git and PR operations
+  - `main.go` - Register `ProposalCmd` in CLI
+- **User-visible changes**: One new command
+- **Dependencies**: Requires `git` and platform-specific PR CLI (`gh`, `glab`, or `tea`) installed

--- a/spectr/changes/add-propose-command/specs/cli-interface/spec.md
+++ b/spectr/changes/add-propose-command/specs/cli-interface/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Propose Command for Automated PR Creation
+
+The `spectr propose <change-id>` command SHALL automate the workflow of creating a pull request from a newly scaffolded change proposal. It SHALL validate that the change exists and is uncommitted, create a dedicated git branch, stage only the change folder, commit the changes, push to the remote, and invoke the appropriate PR creation tool based on the git hosting platform.
+
+#### Scenario: User creates PR for a new proposal
+
+- **WHEN** user runs `spectr propose my-feature`
+- **AND** the change proposal exists in `spectr/changes/my-feature/`
+- **AND** the folder is not yet committed to git
+- **AND** a git repository with an `origin` remote is configured
+- **THEN** a new branch named `add-my-feature` is created
+- **AND** only the `spectr/changes/my-feature/` folder is staged and committed
+- **AND** the branch is pushed to the origin remote
+- **AND** the appropriate PR CLI tool is invoked (gh, glab, or tea)
+- **AND** the PR is created with title "Propose: my-feature"
+- **AND** the PR body includes the purpose and changes from the proposal
+- **AND** the PR URL is displayed to the user
+
+#### Scenario: Git platform auto-detection for GitHub
+
+- **WHEN** the `origin` remote URL contains `github.com`
+- **THEN** the `gh pr create` command is used
+- **AND** the PR is created on GitHub
+
+#### Scenario: Git platform auto-detection for GitLab
+
+- **WHEN** the `origin` remote URL contains `gitlab.com` or is a self-hosted GitLab instance
+- **THEN** the `glab mr create` command is used
+- **AND** the MR (merge request) is created on GitLab
+
+#### Scenario: Git platform auto-detection for Gitea
+
+- **WHEN** the `origin` remote URL contains `gitea` or `forgejo`
+- **THEN** the `tea pr create` command is used
+- **AND** the PR is created on Gitea or Forgejo
+
+#### Scenario: Change folder does not exist
+
+- **WHEN** user runs `spectr propose non-existent`
+- **AND** the folder `spectr/changes/non-existent/` does not exist
+- **THEN** an error is displayed: "Change proposal 'non-existent' not found in spectr/changes/"
+- **AND** no git operations occur
+- **AND** the command exits with error code 1
+
+#### Scenario: Change folder is already committed
+
+- **WHEN** user runs `spectr propose already-tracked`
+- **AND** the folder `spectr/changes/already-tracked/` is already tracked by git
+- **THEN** an error is displayed: "Change 'already-tracked' is already committed. Use git/gh/glab/tea directly to create a PR."
+- **AND** no branch is created
+- **AND** the command exits with error code 1
+
+#### Scenario: Not in a git repository
+
+- **WHEN** user runs `spectr propose my-feature`
+- **AND** the current directory is not inside a git repository
+- **THEN** an error is displayed: "Not in a git repository. Initialize git with 'git init'."
+- **AND** the command exits with error code 1
+
+#### Scenario: Origin remote not configured
+
+- **WHEN** user runs `spectr propose my-feature`
+- **AND** the change folder exists and is uncommitted
+- **AND** the git repository has no `origin` remote
+- **THEN** an error is displayed: "No 'origin' remote configured. Run 'git remote add origin <url>' first."
+- **AND** no branch is created
+- **AND** the command exits with error code 1
+
+#### Scenario: Git hosting platform not detected
+
+- **WHEN** user runs `spectr propose my-feature`
+- **AND** the origin remote URL does not match GitHub, GitLab, or Gitea patterns
+- **THEN** an error is displayed: "Could not detect git hosting platform. Remote URL: [url]. Please create PR manually using gh, glab, or tea."
+- **AND** the branch is created and pushed, but PR creation is not attempted
+- **AND** the command exits with error code 1
+
+#### Scenario: PR CLI tool not installed
+
+- **WHEN** user runs `spectr propose my-feature` for a GitHub repository
+- **AND** the `gh` CLI tool is not installed
+- **THEN** an error is displayed: "gh not found. Install from https://github.com/cli/cli"
+- **AND** the branch is created and pushed, but the PR is not created
+- **AND** the command exits with error code 1
+
+#### Scenario: Unrelated uncommitted changes are not included
+
+- **WHEN** user has uncommitted changes in other directories (not in `spectr/changes/my-feature/`)
+- **AND** runs `spectr propose my-feature`
+- **THEN** only the `spectr/changes/my-feature/` folder is staged and committed
+- **AND** unrelated uncommitted changes remain in the working tree
+
+#### Scenario: PR creation succeeds and URL is displayed
+
+- **WHEN** the PR is successfully created
+- **THEN** a success message is displayed with the PR URL
+- **AND** the message format is "PR created: https://github.com/owner/repo/pull/123"
+- **AND** the command exits with code 0

--- a/spectr/changes/add-propose-command/tasks.md
+++ b/spectr/changes/add-propose-command/tasks.md
@@ -1,0 +1,58 @@
+# Tasks: Implement `spectr propose` Command
+
+## 1. Core Implementation
+
+- [ ] 1.1 Create `internal/propose/` package directory
+- [ ] 1.2 Create `internal/propose/proposer.go` with main Proposer struct
+- [ ] 1.3 Implement git platform detection from remote URL
+- [ ] 1.4 Implement git operations (branch creation, staging, commit, push)
+- [ ] 1.5 Implement PR CLI tool selection and invocation logic
+- [ ] 1.6 Implement PR URL extraction from tool output
+- [ ] 1.7 Add error handling for all git and CLI operations
+
+## 2. Command Integration
+
+- [ ] 2.1 Create `cmd/propose.go` with ProposeCmd struct
+- [ ] 2.2 Register ProposeCmd in `cmd/root.go` CLI struct
+- [ ] 2.3 Implement ProposeCmd.Run() method
+- [ ] 2.4 Add command help text and flag descriptions
+
+## 3. Validation & Safety
+
+- [ ] 3.1 Validate that change folder exists before any git operations
+- [ ] 3.2 Validate that change folder is NOT tracked by git
+- [ ] 3.3 Validate git repository exists (has .git directory)
+- [ ] 3.4 Validate origin remote is configured
+- [ ] 3.5 Validate required PR CLI tool is installed
+
+## 4. Testing
+
+- [ ] 4.1 Create `internal/propose/proposer_test.go` with unit tests
+- [ ] 4.2 Test git platform detection for GitHub, GitLab, Gitea URLs
+- [ ] 4.3 Test git operations (mocked git calls)
+- [ ] 4.4 Test PR CLI tool selection logic
+- [ ] 4.5 Test error cases (missing change, already tracked, no remote)
+- [ ] 4.6 Test PR URL extraction from different tool outputs
+- [ ] 4.7 Create `cmd/propose_test.go` with command integration tests
+
+## 5. Documentation & Verification
+
+- [ ] 5.1 Verify command works end-to-end with a real change proposal
+- [ ] 5.2 Test on Linux, macOS, and Windows (or use CI)
+- [ ] 5.3 Ensure error messages are helpful and actionable
+- [ ] 5.4 Add inline comments for complex logic
+
+## 6. Polish
+
+- [ ] 6.1 Run `golangci-lint` and fix any linting issues
+- [ ] 6.2 Ensure all exported functions have doc comments
+- [ ] 6.3 Test with edge cases (spaces in change ID, special chars in URL)
+- [ ] 6.4 Verify that unrelated uncommitted changes are not included in commit
+
+---
+
+**Completion Criteria**:
+- All tests pass
+- No linting errors
+- Command successfully creates a PR for a new change proposal
+- All error paths are tested and provide clear guidance


### PR DESCRIPTION
This pull request introduces a new `spectr propose <id>` command to automate the process of creating a pull request from a newly scaffolded change proposal. The command streamlines the workflow by handling branch creation, commit, push, and PR creation using the appropriate CLI tool for the detected git hosting platform (GitHub, GitLab, or Gitea). It includes robust validation and error handling to guide users through common failure scenarios, and ensures only the intended change folder is committed. The following are the most important changes:

**Design and Specification**

* Added a detailed design document (`design.md`) outlining the workflow, platform detection logic, branch naming convention, commit strategy, PR creation, error handling, and cross-platform support for the new `spectr propose` command.
* Updated CLI interface specification (`spec.md`) with requirements, scenarios, and expected behaviors for the new command, including platform auto-detection, error cases, and success messages.

**Feature Implementation Planning**

* Added a change proposal (`proposal.md`) describing the motivation, changes, impact, affected specs/code, and dependencies for introducing the `spectr propose` command.
* Created a comprehensive implementation task list (`tasks.md`) covering core logic, command integration, validation, testing, documentation, and polish steps for the new feature.