### PR TITLE
Add Spectr proposal to remove ConfigPath from ToolDefinition

### DIFF
--- a/spectr/changes/remove-configpath-tooldefinition/proposal.md
+++ b/spectr/changes/remove-configpath-tooldefinition/proposal.md
@@ -1,0 +1,29 @@
+# Change: Remove ConfigPath from ToolDefinition
+
+## Why
+
+The `ConfigPath` field in `ToolDefinition` (internal/init/models.go:24) is misleading and serves no functional purpose. While it's set for each tool in the registry and returned by `getToolFileInfo()`, it's never actually used to determine where files are created. Each configurator hardcodes its own file path independently:
+
+- `ClaudeCodeConfigurator` uses `"CLAUDE.md"` (configurator.go:163)
+- `ClineConfigurator` uses `"CLINE.md"` (configurator.go:193)
+- `CostrictConfigurator` uses `"COSTRICT.md"` (configurator.go:221)
+
+The values stored in `ConfigPath` (like `.claude/claude.json`, `.cline/cline_mcp_settings.json`) don't match the actual files created and are never referenced when creating configuration files. This creates confusion and maintenance overhead.
+
+## What Changes
+
+- **BREAKING**: Remove `ConfigPath` field from `ToolDefinition` struct
+- Remove `ConfigPath` assignments in `registry.go` for all tools
+- Update `getToolFileInfo()` to return actual file paths from configurators instead of using ConfigPath
+- Update tests that reference ConfigPath
+- No user-facing behavior changes (files are still created in the same locations)
+
+## Impact
+
+- Affected specs: cli-interface (initialization wizard and tool configuration)
+- Affected code:
+  - `internal/init/models.go` - remove field from struct
+  - `internal/init/registry.go` - remove ConfigPath assignments
+  - `internal/init/executor.go` - update getToolFileInfo logic
+  - `internal/init/registry_test.go` - remove ConfigPath assertions
+  - `internal/init/init_test.go` - update tests if needed

--- a/spectr/changes/remove-configpath-tooldefinition/specs/cli-interface/spec.md
+++ b/spectr/changes/remove-configpath-tooldefinition/specs/cli-interface/spec.md
@@ -1,0 +1,63 @@
+# Cli Interface Delta Specification
+
+## MODIFIED Requirements
+
+### Requirement: Automatic Slash Command Installation
+
+When a config-based AI tool is selected during initialization, the system SHALL automatically install the corresponding slash command files for that tool without requiring separate user selection.
+
+Config-based tools include those that create instruction files (e.g., `claude-code` creates `CLAUDE.md`). Slash command files are the workflow command files (e.g., `.claude/commands/spectr/proposal.md`).
+
+The `ToolDefinition` model SHALL NOT include a `ConfigPath` field, as actual file paths are determined by individual configurators. The registry maintains tool metadata (ID, Name, Type, Priority) but delegates file path resolution to configurator implementations.
+
+This automatic installation provides users with complete Spectr integration in a single selection, eliminating the need for redundant tool entries in the wizard.
+
+#### Scenario: Claude Code auto-installs slash commands
+
+- **WHEN** user selects `claude-code` in the init wizard
+- **THEN** the system creates `CLAUDE.md` in the project root
+- **AND** the system creates `.claude/commands/spectr/proposal.md`
+- **AND** the system creates `.claude/commands/spectr/apply.md`
+- **AND** the system creates `.claude/commands/spectr/archive.md`
+- **AND** all files are tracked in the execution result
+- **AND** the completion screen shows all 4 files created
+
+#### Scenario: Multiple tools with slash commands selected
+
+- **WHEN** user selects both `claude-code` and `cursor` in the init wizard
+- **THEN** the system creates `CLAUDE.md` and both config + slash commands for Claude
+- **AND** the system creates `.cursor/commands/spectr-proposal.md` and slash commands for Cursor
+- **AND** all files from both tools are created and tracked separately
+- **AND** the completion screen lists all created files grouped by tool
+
+#### Scenario: Slash command files already exist
+
+- **WHEN** user runs init and selects `claude-code`
+- **AND** `.claude/commands/spectr/proposal.md` already exists
+- **THEN** the existing file's content between `<!-- spectr:START -->` and `<!-- spectr:END -->` is updated
+- **AND** the file's YAML frontmatter is preserved
+- **AND** no error occurs
+- **AND** the file is marked as "updated" rather than "created" in execution result
+
+#### Scenario: Config-based tool without slash mapping
+
+- **WHEN** a config-based tool has no slash command equivalent in the mapping
+- **THEN** only the config file is created
+- **AND** no error occurs
+- **AND** the system continues with remaining tool configurations
+
+#### Scenario: Tool mapping is explicit and centralized
+
+- **WHEN** a developer reviews the mapping logic
+- **THEN** they find a `configToSlashMapping` map in `internal/init/registry.go`
+- **AND** the map contains explicit entries for each tool pair
+- **AND** the mapping includes all 11 tools with slash command variants
+- **AND** the map can be extended for new tools
+
+#### Scenario: ToolDefinition structure simplified
+
+- **WHEN** a developer reviews the ToolDefinition struct in `internal/init/models.go`
+- **THEN** the struct contains: ID, Name, Type, Priority, and Configured fields
+- **AND** the struct does NOT contain a ConfigPath field
+- **AND** file paths are determined by configurator implementations, not the registry
+- **AND** the `getToolFileInfo()` function queries configurators for actual file paths

--- a/spectr/changes/remove-configpath-tooldefinition/tasks.md
+++ b/spectr/changes/remove-configpath-tooldefinition/tasks.md
@@ -1,0 +1,11 @@
+# Implementation Tasks
+
+## 1. Remove ConfigPath from ToolDefinition
+
+- [ ] 1.1 Remove `ConfigPath string` field from ToolDefinition struct in `internal/init/models.go`
+- [ ] 1.2 Remove ConfigPath assignments from all tool registrations in `internal/init/registry.go` (6 tools)
+- [ ] 1.3 Update `getToolFileInfo()` in `internal/init/executor.go` to return actual configurator file paths
+- [ ] 1.4 Remove ConfigPath assertions from `internal/init/registry_test.go`
+- [ ] 1.5 Run tests to verify no regressions: `go test ./internal/init/...`
+- [ ] 1.6 Run full test suite: `go test ./...`
+- [ ] 1.7 Verify the build compiles: `go build`


### PR DESCRIPTION
Create change proposal for removing the unused ConfigPath field from the ToolDefinition struct. The field is never used to determine actual file paths - each configurator hardcodes its own paths independently.

This change eliminates confusion and reduces maintenance overhead while maintaining all existing behavior.