### PR TITLE
Add proposal for spectr show browser renderer

### DIFF
--- a/spectr/changes/add-show-command/design.md
+++ b/spectr/changes/add-show-command/design.md
@@ -1,0 +1,360 @@
+# Design: Browser-Based Markdown Renderer for Spectr
+
+## Context
+
+Spectr specifications and change proposals are complex Markdown documents that benefit from rich rendering with images, math notation, and proper typography. This design document outlines the technical approach for a browser-based renderer using Goldmark and MathJax.
+
+**Background:**
+- Specs contain requirements with scenarios in structured Markdown format
+- Changes contain multiple files (proposal.md, tasks.md, design.md, delta specs)
+- Users need to review specs visually with rendered images and math
+- Current workflow requires manual conversion or external tools
+
+**Constraints:**
+- Must work on Linux, macOS, and Windows
+- Must not require external dependencies beyond Go toolchain
+- Must handle relative image paths correctly
+- Must render MathJax without network access issues (CDN fallback)
+
+**Stakeholders:**
+- Developers reviewing specs and changes
+- Product managers and stakeholders reviewing proposals
+- Technical writers authoring specifications
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render specs and changes as polished HTML in browser
+- Support MathJax for mathematical notation (`$inline$` and `$$display$$`)
+- Resolve image paths relative to spec/change directory and project root
+- Start ephemeral HTTP server with auto-assigned port
+- Auto-open browser to rendered content
+- Clean, minimal CSS for readability
+
+**Non-Goals:**
+- Live reload on file changes (future enhancement)
+- PDF export (future enhancement)
+- Editing specs in browser (read-only view)
+- Custom themes or CSS customization (future enhancement)
+- Offline MathJax bundling (CDN is acceptable)
+
+## Decisions
+
+### Decision 1: Use Goldmark for Markdown Parsing
+
+**Chosen:** Goldmark (`github.com/yuin/goldmark`)
+
+**Rationale:**
+- De facto standard Markdown parser in Go ecosystem
+- CommonMark compliant with extensions support
+- Used by Hugo, GitHub, and other major projects
+- Excellent performance and correctness
+- Supports tables, strikethrough, task lists via extensions
+
+**Alternatives considered:**
+- `blackfriday`: Older, less actively maintained
+- `gomarkdown/markdown`: Fewer features, less ecosystem adoption
+
+### Decision 2: HTTP Server with Auto-Assigned Port
+
+**Chosen:** Ephemeral HTTP server with port auto-assignment (`:0`)
+
+**Rationale:**
+- Avoids port conflicts (user may have multiple specs open)
+- Simple stdlib implementation with `net/http`
+- Allows MathJax and images to load without CORS issues (unlike `file://` protocol)
+- Server URL printed to terminal for manual browser access
+
+**Alternatives considered:**
+- Static HTML file with `file://` protocol: CORS issues prevent MathJax from loading
+- Fixed port (e.g., 8080): Port conflicts when multiple instances run
+
+### Decision 3: MathJax from CDN
+
+**Chosen:** MathJax 3.x from CDN (https://cdn.jsdelivr.net/npm/mathjax@3/...)
+
+**Rationale:**
+- No bundling required (keeps binary size small)
+- Always up-to-date with latest MathJax version
+- Widely available CDN with high reliability
+- Graceful degradation if CDN unreachable (shows raw LaTeX)
+
+**Alternatives considered:**
+- Bundle MathJax in binary: 10+ MB increase in binary size
+- KaTeX: Faster but less feature-complete for complex math
+
+**Configuration:**
+```javascript
+MathJax = {
+  tex: {
+    inlineMath: [['$', '$']],
+    displayMath: [['$$', '$$']]
+  }
+};
+```
+
+### Decision 4: Image Path Resolution Strategy
+
+**Chosen:** Multi-pass resolution with fallback
+
+1. Resolve relative to spec/change directory (e.g., `spectr/specs/auth/diagram.png`)
+2. Fallback to project root (e.g., `./assets/diagram.png`)
+3. Return 404 if neither exists
+
+**Rationale:**
+- Supports both spec-local images and shared project assets
+- Predictable path resolution for users
+- Allows organizing images alongside specs or centrally
+
+**Implementation:**
+```go
+// HTTP handler for /images/<path>
+func (s *Server) serveImage(w http.ResponseWriter, r *http.Request, imagePath string) {
+    // Try spec/change directory first
+    fullPath := filepath.Join(s.itemDir, imagePath)
+    if fileExists(fullPath) {
+        http.ServeFile(w, r, fullPath)
+        return
+    }
+    // Fallback to project root
+    fullPath = filepath.Join(s.projectRoot, imagePath)
+    if fileExists(fullPath) {
+        http.ServeFile(w, r, fullPath)
+        return
+    }
+    http.NotFound(w, r)
+}
+```
+
+### Decision 5: Combined View for Changes
+
+**Chosen:** Render all change files in tabbed sections
+
+**Structure:**
+- **Proposal** tab: Rendered `proposal.md`
+- **Tasks** tab: Rendered `tasks.md` with checkboxes
+- **Design** tab: Rendered `design.md` (if exists)
+- **Deltas** tab: All delta specs combined with capability headers
+
+**Rationale:**
+- Single-page view eliminates need to open multiple files
+- Tab navigation provides organized access to each section
+- Capability headers in deltas tab clarify which spec is affected
+
+**HTML structure:**
+```html
+<div class="tabs">
+  <button class="tab active" onclick="showTab('proposal')">Proposal</button>
+  <button class="tab" onclick="showTab('tasks')">Tasks</button>
+  <button class="tab" onclick="showTab('design')">Design</button>
+  <button class="tab" onclick="showTab('deltas')">Deltas</button>
+</div>
+<div id="proposal" class="tab-content active">...</div>
+<div id="tasks" class="tab-content">...</div>
+<div id="design" class="tab-content">...</div>
+<div id="deltas" class="tab-content">...</div>
+```
+
+### Decision 6: Auto-Open Browser
+
+**Chosen:** Use `browser.OpenURL()` from `pkg/browser` or similar
+
+**Rationale:**
+- Cross-platform browser opening without platform-specific code
+- Respects user's default browser preference
+- Graceful fallback if browser opening fails (print URL)
+
+**Implementation:**
+```go
+url := fmt.Sprintf("http://localhost:%d", port)
+fmt.Printf("Opening browser at %s\n", url)
+if err := browser.OpenURL(url); err != nil {
+    fmt.Printf("Failed to open browser: %v\n", err)
+    fmt.Printf("Please open manually: %s\n", url)
+}
+```
+
+**Library:** `github.com/pkg/browser` or equivalent
+
+## Architecture
+
+### Package Structure
+
+```
+internal/show/
+├── renderer.go       # Goldmark setup, Markdown → HTML conversion
+├── server.go         # HTTP server with /images handler
+├── templates.go      # HTML template with MathJax, CSS
+├── item_loader.go    # Load spec or change files
+└── browser.go        # Browser opening utility
+```
+
+### Data Flow
+
+```
+User runs: spectr show auth --type spec
+                ↓
+         cmd/show.go (ShowCmd.Run)
+                ↓
+    Determine item type and paths
+                ↓
+    show.LoadItem(itemID, itemType, projectPath)
+                ↓
+  Read Markdown files (spec.md or proposal.md + tasks.md + ...)
+                ↓
+    show.RenderMarkdown(content) using Goldmark
+                ↓
+    show.WrapInTemplate(html) with MathJax + CSS
+                ↓
+    show.StartServer(html, itemDir, projectRoot)
+                ↓
+  HTTP server starts on :0 (auto-assigned port)
+                ↓
+    browser.OpenURL(http://localhost:<port>)
+                ↓
+  Server serves /index.html and /images/<path>
+                ↓
+  User views rendered content in browser
+                ↓
+  User presses Ctrl+C to stop server
+```
+
+### HTTP Routes
+
+- `GET /` → Rendered HTML content
+- `GET /images/<path>` → Image files (with fallback resolution)
+
+### HTML Template
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{.Title}}</title>
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <script>
+        MathJax = {
+            tex: {
+                inlineMath: [['$', '$']],
+                displayMath: [['$$', '$$']]
+            }
+        };
+    </script>
+    <style>
+        /* Clean, readable CSS */
+        body { max-width: 900px; margin: 40px auto; font-family: system-ui; line-height: 1.6; }
+        h1, h2, h3, h4 { margin-top: 1.5em; }
+        pre { background: #f5f5f5; padding: 1em; overflow-x: auto; }
+        code { background: #f5f5f5; padding: 0.2em 0.4em; border-radius: 3px; }
+        img { max-width: 100%; height: auto; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background: #f5f5f5; }
+        .tabs { border-bottom: 1px solid #ddd; margin-bottom: 20px; }
+        .tab { padding: 10px 20px; border: none; background: none; cursor: pointer; }
+        .tab.active { border-bottom: 2px solid #0066cc; color: #0066cc; }
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+    </style>
+</head>
+<body>
+    {{if .HasTabs}}
+        <div class="tabs">
+            {{range .Tabs}}
+                <button class="tab {{if .Active}}active{{end}}" onclick="showTab('{{.ID}}')">{{.Label}}</button>
+            {{end}}
+        </div>
+        {{range .TabContents}}
+            <div id="{{.ID}}" class="tab-content {{if .Active}}active{{end}}">
+                {{.HTML}}
+            </div>
+        {{end}}
+        <script>
+            function showTab(tabID) {
+                document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+                document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+                event.target.classList.add('active');
+                document.getElementById(tabID).classList.add('active');
+            }
+        </script>
+    {{else}}
+        {{.HTML}}
+    {{end}}
+</body>
+</html>
+```
+
+## Risks / Trade-offs
+
+### Risk: CDN Unavailability
+
+**Description:** MathJax CDN may be unreachable in air-gapped environments
+
+**Impact:** Math notation displays as raw LaTeX (readable but not rendered)
+
+**Mitigation:**
+- Document requirement for internet access in README
+- Future enhancement: `--offline` flag to use bundled MathJax
+
+### Risk: Port Conflicts
+
+**Description:** Auto-assigned port may still conflict if OS assigns already-used port
+
+**Impact:** Server fails to start
+
+**Mitigation:**
+- Use `:0` for OS-level port assignment (avoids most conflicts)
+- Retry with new port if bind fails (up to 3 attempts)
+- Print clear error message with retry instructions
+
+### Risk: Browser Opening Failures
+
+**Description:** `browser.OpenURL()` may fail on headless systems or restricted environments
+
+**Impact:** User must manually copy URL to browser
+
+**Mitigation:**
+- Always print URL to terminal as fallback
+- Graceful degradation with clear instructions
+- Document usage for SSH/remote environments
+
+### Risk: Large Markdown Files
+
+**Description:** Very large specs (>10MB) may be slow to render
+
+**Impact:** Browser may hang or be sluggish
+
+**Mitigation:**
+- Goldmark is fast enough for typical specs (<1MB)
+- Add warning if file size >5MB (future enhancement)
+- Consider pagination for large changes (future enhancement)
+
+## Migration Plan
+
+No migration required. This is a new command with no breaking changes.
+
+**Rollout:**
+1. Implement `spectr show` command
+2. Add tests for renderer, server, and path resolution
+3. Update documentation with examples
+4. Add to CLI help text and README
+
+**Testing:**
+- Unit tests for Markdown rendering
+- Integration tests for HTTP server
+- Manual testing with sample specs containing images and math
+
+**Rollback:**
+- If issues arise, command can be disabled or removed without affecting existing workflows
+
+## Open Questions
+
+1. **Syntax highlighting**: Should we add syntax highlighting for code blocks?
+   - **Answer**: Yes, use Goldmark's syntax highlighting extension with Chroma
+2. **Table of contents**: Should we generate TOC for long specs?
+   - **Answer**: Future enhancement, not in initial implementation
+3. **Dark mode**: Should we support dark mode CSS?
+   - **Answer**: Future enhancement, start with light mode only
+4. **Spec linking**: Should we support links between specs (e.g., `[auth spec](spec://auth)`)?
+   - **Answer**: Future enhancement, use standard Markdown links for now

--- a/spectr/changes/add-show-command/proposal.md
+++ b/spectr/changes/add-show-command/proposal.md
@@ -1,0 +1,46 @@
+# Change: Add `spectr show` Browser Renderer with Goldmark and MathJax
+
+## Why
+
+Spectr specifications and change proposals are written in Markdown, which often includes complex formatting, diagrams (images), and mathematical notation. While Markdown is human-readable in plain text, rendering it in a browser provides:
+- **Better readability**: Proper typography, syntax highlighting, and layout
+- **Rich media support**: Inline images and diagrams render visually
+- **Mathematical notation**: MathJax renders LaTeX-style math (`$...$` and `$$...$$`) for technical specifications
+- **Improved collaboration**: Stakeholders can review specs in a polished format without learning Markdown
+
+Currently, users must manually convert Markdown to HTML or use external tools. A `spectr show` command that auto-renders specs and changes in the browser streamlines the review process and improves the developer/stakeholder experience.
+
+## What Changes
+
+- **NEW**: Add `spectr show <item>` command that:
+  - Accepts a spec ID (e.g., `spectr show auth --type spec`) or change ID (e.g., `spectr show add-2fa --type change`)
+  - Renders Markdown content to HTML using **Goldmark** (Go's standard Markdown parser)
+  - Starts a local HTTP server (e.g., `http://localhost:8080`) with auto-assigned port
+  - Serves rendered HTML with:
+    - **MathJax** integration for math rendering (`$inline$` and `$$display$$`)
+    - **Image support** with path resolution (spec/change directory → project root fallback)
+    - Clean, readable CSS styling with proper typography
+    - Syntax highlighting for code blocks
+  - Automatically opens the rendered page in the user's default browser
+  - Keeps server running until user terminates (Ctrl+C)
+  - Displays server URL in terminal for manual access
+- **For specs**: Renders `spectr/specs/<id>/spec.md`
+- **For changes**: Renders a combined view of `proposal.md`, `tasks.md`, `design.md`, and all delta specs
+- **BREAKING**: None
+
+## Impact
+
+- **Affected specs**: `cli-interface`, `cli-framework`
+- **Affected code**:
+  - `cmd/` - Add `ShowCmd` command handler (wait, there's already a view command, so we need to check if "show" is taken)
+  - `internal/` - New `show` package with:
+    - Markdown rendering with Goldmark
+    - HTTP server with static asset serving
+    - MathJax template integration
+    - Image path resolution
+  - `go.mod` - Add `github.com/yuin/goldmark` dependency
+- **User-visible changes**: One new command
+- **Dependencies**:
+  - `goldmark` for Markdown parsing
+  - Go's `net/http` for local server (stdlib)
+  - MathJax served from CDN (no installation required)

--- a/spectr/changes/add-show-command/specs/cli-framework/spec.md
+++ b/spectr/changes/add-show-command/specs/cli-framework/spec.md
@@ -1,0 +1,78 @@
+# Cli Framework Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Show Command Structure
+The CLI SHALL provide a `show` command that renders specifications or changes as HTML in a browser with support for images and mathematical notation.
+
+#### Scenario: Show command registration
+- **WHEN** the CLI is initialized
+- **THEN** it SHALL include a ShowCmd struct field tagged with `cmd`
+- **AND** the command SHALL be accessible via `spectr show`
+- **AND** help text SHALL describe browser rendering functionality
+
+#### Scenario: Show spec invocation
+- **WHEN** user runs `spectr show <spec-id> --type spec`
+- **THEN** the system renders the spec's Markdown content to HTML
+- **AND** starts an HTTP server on an auto-assigned port
+- **AND** opens the rendered page in the user's default browser
+- **AND** keeps the server running until Ctrl+C is pressed
+
+#### Scenario: Show change invocation
+- **WHEN** user runs `spectr show <change-id> --type change`
+- **THEN** the system renders all change files (proposal.md, tasks.md, design.md, deltas) to HTML
+- **AND** displays content in tabbed sections (Proposal, Tasks, Design, Deltas)
+- **AND** starts an HTTP server and opens browser as with specs
+
+#### Scenario: Auto-detect item type
+- **WHEN** user runs `spectr show <item-id>` without `--type` flag
+- **THEN** the system checks if item exists as a spec in `spectr/specs/<item-id>/`
+- **AND** checks if item exists as a change in `spectr/changes/<item-id>/`
+- **AND** renders whichever is found
+- **AND** displays error if neither exists or if ambiguous (both exist)
+
+#### Scenario: Server URL printed to terminal
+- **WHEN** the HTTP server starts successfully
+- **THEN** the terminal displays message "Opening browser at http://localhost:<port>"
+- **AND** displays message "Press Ctrl+C to stop server"
+- **AND** the server URL is shown for manual browser access
+
+#### Scenario: Server start failure
+- **WHEN** the HTTP server fails to start (e.g., port binding error)
+- **THEN** the system retries with a new port up to 3 times
+- **AND** displays error message if all retries fail
+- **AND** exits with non-zero status code
+
+### Requirement: Show Command Flags
+The show command SHALL support flags for controlling rendering behavior.
+
+#### Scenario: Type disambiguation flag
+- **WHEN** user provides `--type spec` or `--type change`
+- **THEN** the command SHALL treat the item as the specified type
+- **AND** SHALL skip auto-detection
+- **AND** SHALL error if item does not exist as that type
+
+#### Scenario: Port flag for custom port
+- **WHEN** user provides `--port <number>` flag
+- **THEN** the server SHALL attempt to bind to the specified port
+- **AND** SHALL fail if port is already in use (no auto-retry for explicit port)
+- **AND** SHALL validate port is in valid range (1-65535)
+
+### Requirement: Show Command Help Text
+The show command SHALL provide comprehensive help documentation.
+
+#### Scenario: Command help display
+- **WHEN** user invokes `spectr show --help`
+- **THEN** help text SHALL describe browser rendering purpose
+- **AND** SHALL list available flags (--type, --port) with descriptions
+- **AND** SHALL show usage examples for specs and changes
+- **AND** SHALL indicate required positional argument (item ID)
+
+### Requirement: Positional Argument for Item ID
+The show command SHALL accept a required positional argument for the item to render.
+
+#### Scenario: Required item ID argument
+- **WHEN** show command is defined
+- **THEN** it SHALL have an ItemID field tagged with `arg:"" required:"true"`
+- **AND** omitting the argument SHALL display usage error
+- **AND** the argument SHALL be a string representing spec ID or change ID

--- a/spectr/changes/add-show-command/specs/cli-interface/spec.md
+++ b/spectr/changes/add-show-command/specs/cli-interface/spec.md
@@ -1,0 +1,216 @@
+# Cli Interface Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Browser-Based Markdown Rendering
+The show command SHALL render Markdown files to HTML using Goldmark parser with CommonMark compliance and GitHub Flavored Markdown extensions.
+
+#### Scenario: Render spec Markdown to HTML
+- **WHEN** rendering a spec's `spec.md` file
+- **THEN** the system SHALL parse Markdown using Goldmark
+- **AND** SHALL convert to HTML with proper semantic structure
+- **AND** SHALL preserve heading hierarchy (h1, h2, h3, h4)
+- **AND** SHALL render lists, links, and blockquotes correctly
+
+#### Scenario: Support GitHub Flavored Markdown extensions
+- **WHEN** rendering Markdown content
+- **THEN** tables SHALL render as HTML tables with proper borders and styling
+- **AND** strikethrough text SHALL render with `<del>` tags
+- **AND** task lists SHALL render as checkboxes (checked or unchecked)
+- **AND** autolinks SHALL convert URLs to clickable links
+
+#### Scenario: Syntax highlighting for code blocks
+- **WHEN** rendering fenced code blocks with language identifiers
+- **THEN** the system SHALL apply syntax highlighting using Chroma or similar
+- **AND** SHALL support common languages (Go, JavaScript, Python, Bash, Markdown)
+- **AND** SHALL render with readable color scheme on light background
+
+### Requirement: MathJax Integration for Mathematical Notation
+The show command SHALL render LaTeX-style mathematical notation using MathJax 3.x from CDN.
+
+#### Scenario: Inline math rendering
+- **WHEN** Markdown content contains inline math delimited by single dollar signs (`$...$`)
+- **THEN** MathJax SHALL render the math inline with surrounding text
+- **AND** SHALL use proper font sizing and alignment
+- **EXAMPLE**: `The formula $E = mc^2$ shows` renders as "The formula E = mc² shows"
+
+#### Scenario: Display math rendering
+- **WHEN** Markdown content contains display math delimited by double dollar signs (`$$...$$`)
+- **THEN** MathJax SHALL render the math as a centered block
+- **AND** SHALL use larger font size than inline math
+- **EXAMPLE**: `$$\int_0^\infty e^{-x^2} dx$$` renders as centered integral
+
+#### Scenario: MathJax CDN loading
+- **WHEN** the HTML page is rendered
+- **THEN** MathJax SHALL load from `https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js`
+- **AND** SHALL configure tex input with inlineMath: `[['$', '$']]` and displayMath: `[['$$', '$$']]`
+- **AND** SHALL allow time for CDN to load before user views page
+
+#### Scenario: MathJax unavailable graceful degradation
+- **WHEN** MathJax CDN is unreachable (offline environment)
+- **THEN** raw LaTeX notation SHALL display as plain text
+- **AND** dollar signs SHALL remain visible
+- **AND** no rendering errors SHALL block page display
+
+### Requirement: Image Path Resolution with Fallback
+The show command's HTTP server SHALL resolve image paths relative to the spec/change directory first, then fall back to project root.
+
+#### Scenario: Serve spec-local images
+- **WHEN** Markdown contains image reference `![diagram](./diagram.png)`
+- **AND** file exists at `spectr/specs/<spec-id>/diagram.png`
+- **THEN** the HTTP server SHALL serve the file from the spec directory
+- **AND** SHALL set correct Content-Type header (image/png, image/jpeg, image/svg+xml)
+
+#### Scenario: Serve project-root images as fallback
+- **WHEN** Markdown contains image reference `![logo](assets/logo.png)`
+- **AND** file does NOT exist in spec/change directory
+- **AND** file exists at `./assets/logo.png` (project root)
+- **THEN** the HTTP server SHALL serve the file from project root
+- **AND** SHALL set correct Content-Type header
+
+#### Scenario: Image not found returns 404
+- **WHEN** Markdown contains image reference `![missing](./missing.png)`
+- **AND** file does NOT exist in spec/change directory or project root
+- **THEN** the HTTP server SHALL return HTTP 404 Not Found
+- **AND** browser SHALL display broken image placeholder
+
+#### Scenario: HTTP route for images
+- **WHEN** browser requests image at `/images/<path>`
+- **THEN** the server SHALL resolve `<path>` using fallback strategy
+- **AND** SHALL rewrite Markdown image URLs to use `/images/` prefix during rendering
+
+### Requirement: Tabbed Interface for Changes
+The show command SHALL render changes with tabbed sections for Proposal, Tasks, Design, and Deltas.
+
+#### Scenario: Render change with all files
+- **WHEN** showing a change that has proposal.md, tasks.md, design.md, and delta specs
+- **THEN** the HTML SHALL display 4 tabs: "Proposal", "Tasks", "Design", "Deltas"
+- **AND** the Proposal tab SHALL be active by default
+- **AND** each tab SHALL display the rendered Markdown content for that file
+
+#### Scenario: Switch between tabs
+- **WHEN** user clicks a tab button
+- **THEN** the previously active tab content SHALL hide
+- **AND** the clicked tab content SHALL display
+- **AND** the clicked tab button SHALL gain "active" visual styling
+- **AND** tab switching SHALL work via JavaScript without page reload
+
+#### Scenario: Handle missing design.md
+- **WHEN** showing a change that lacks design.md
+- **THEN** the Design tab SHALL NOT be displayed
+- **AND** only Proposal, Tasks, and Deltas tabs SHALL appear
+- **AND** tab layout SHALL adjust accordingly
+
+#### Scenario: Combine delta specs in Deltas tab
+- **WHEN** rendering the Deltas tab
+- **THEN** all delta spec files under `specs/<capability>/spec.md` SHALL be combined
+- **AND** each delta SHALL be prefixed with a heading showing the capability name
+- **AND** deltas SHALL be sorted alphabetically by capability ID
+
+### Requirement: Clean, Readable HTML Styling
+The show command SHALL apply CSS styling for readability and professional appearance.
+
+#### Scenario: Typography and layout
+- **WHEN** rendering HTML
+- **THEN** body text SHALL use system font stack (system-ui, sans-serif)
+- **AND** line height SHALL be at least 1.6 for readability
+- **AND** content SHALL be centered with max-width of 900px
+- **AND** body SHALL have left/right margin of 40px
+
+#### Scenario: Heading hierarchy styling
+- **WHEN** rendering headings
+- **THEN** h1, h2, h3, h4 SHALL have increased top margin (1.5em) for visual separation
+- **AND** SHALL use bold font weight
+- **AND** SHALL maintain relative font sizes (h1 largest, h4 smallest)
+
+#### Scenario: Code block styling
+- **WHEN** rendering code blocks
+- **THEN** background SHALL be light gray (#f5f5f5)
+- **AND** padding SHALL be 1em for spacing
+- **AND** horizontal overflow SHALL scroll if content is too wide
+- **AND** font SHALL be monospace with readable size
+
+#### Scenario: Table styling
+- **WHEN** rendering tables
+- **THEN** borders SHALL be visible with 1px solid (#ddd)
+- **AND** cells SHALL have padding of 8px
+- **AND** header row SHALL have distinct background (#f5f5f5)
+- **AND** table SHALL use full width of content area
+
+#### Scenario: Image responsive sizing
+- **WHEN** rendering images
+- **THEN** max-width SHALL be 100% to prevent overflow
+- **AND** height SHALL auto-scale to maintain aspect ratio
+- **AND** images SHALL not exceed content width
+
+### Requirement: Auto-Open Browser
+The show command SHALL automatically open the rendered page in the user's default browser.
+
+#### Scenario: Successful browser opening
+- **WHEN** HTTP server starts successfully
+- **THEN** the system SHALL invoke browser.OpenURL() with server URL
+- **AND** SHALL use cross-platform browser opening library (pkg/browser)
+- **AND** SHALL respect user's default browser preference (system setting)
+
+#### Scenario: Browser opening failure
+- **WHEN** browser.OpenURL() fails (e.g., headless environment)
+- **THEN** the system SHALL print error message to terminal
+- **AND** SHALL display fallback message "Please open manually: http://localhost:<port>"
+- **AND** SHALL continue running server (not exit on browser failure)
+
+#### Scenario: Cross-platform browser support
+- **WHEN** running on Linux
+- **THEN** the system SHALL use xdg-open or equivalent to open browser
+- **WHEN** running on macOS
+- **THEN** the system SHALL use open command to open browser
+- **WHEN** running on Windows
+- **THEN** the system SHALL use start command to open browser
+
+### Requirement: Ephemeral HTTP Server
+The show command SHALL start a local HTTP server on an auto-assigned port that runs until user terminates it.
+
+#### Scenario: Auto-assign port with :0
+- **WHEN** starting HTTP server without `--port` flag
+- **THEN** the system SHALL bind to address `:0` for OS-level port assignment
+- **AND** SHALL retrieve the assigned port number from the listener
+- **AND** SHALL print the assigned port in terminal output
+
+#### Scenario: Server runs until interrupted
+- **WHEN** HTTP server is running
+- **THEN** it SHALL continue serving requests until Ctrl+C is pressed
+- **AND** SHALL handle SIGINT signal for graceful shutdown
+- **AND** SHALL close listener and exit cleanly on interrupt
+
+#### Scenario: Serve index route
+- **WHEN** browser requests `GET /`
+- **THEN** the server SHALL respond with rendered HTML content
+- **AND** SHALL set Content-Type header to `text/html; charset=utf-8`
+- **AND** SHALL respond with HTTP 200 OK
+
+#### Scenario: Serve images route
+- **WHEN** browser requests `GET /images/<path>`
+- **THEN** the server SHALL resolve image path with fallback strategy
+- **AND** SHALL serve file with appropriate Content-Type
+- **AND** SHALL respond with HTTP 200 OK for found files, 404 for missing files
+
+### Requirement: Terminal Output for Show Command
+The show command SHALL provide clear terminal output indicating server status and user actions.
+
+#### Scenario: Startup messages
+- **WHEN** show command starts successfully
+- **THEN** terminal SHALL display "Rendering <item-type>: <item-id>"
+- **AND** SHALL display "Starting HTTP server..."
+- **AND** SHALL display "Opening browser at http://localhost:<port>"
+- **AND** SHALL display "Press Ctrl+C to stop server"
+
+#### Scenario: Error messages
+- **WHEN** item does not exist
+- **THEN** terminal SHALL display "Error: <item-type> not found: <item-id>"
+- **AND** SHALL suggest running `spectr list --specs` or `spectr list` to see available items
+- **WHEN** server fails to start
+- **THEN** terminal SHALL display "Error: Failed to start server: <error details>"
+
+#### Scenario: Shutdown message
+- **WHEN** user presses Ctrl+C to stop server
+- **THEN** terminal SHALL display "Shutting down server..."
+- **AND** SHALL exit cleanly with status code 0

--- a/spectr/changes/add-show-command/tasks.md
+++ b/spectr/changes/add-show-command/tasks.md
@@ -1,0 +1,106 @@
+# Implementation Tasks: Add `spectr show` Command
+
+## 1. Setup and Dependencies
+
+- [ ] 1.1 Add `github.com/yuin/goldmark` to go.mod
+- [ ] 1.2 Add goldmark extensions (tables, strikethrough, task lists, syntax highlighting)
+- [ ] 1.3 Add `github.com/pkg/browser` for cross-platform browser opening
+- [ ] 1.4 Create `internal/show/` package directory
+
+## 2. Markdown Renderer
+
+- [ ] 2.1 Create `internal/show/renderer.go` with Goldmark setup
+- [ ] 2.2 Implement `RenderMarkdown(content []byte) (string, error)` function
+- [ ] 2.3 Configure Goldmark extensions (tables, strikethrough, task lists)
+- [ ] 2.4 Add syntax highlighting with Chroma extension
+- [ ] 2.5 Write unit tests for Markdown rendering with fixtures
+
+## 3. HTML Templates
+
+- [ ] 3.1 Create `internal/show/templates.go` with HTML template
+- [ ] 3.2 Implement template with MathJax 3.x CDN integration
+- [ ] 3.3 Add clean, readable CSS with typography and spacing
+- [ ] 3.4 Implement tab-based layout for changes (proposal/tasks/design/deltas)
+- [ ] 3.5 Add JavaScript for tab switching functionality
+- [ ] 3.6 Write unit tests for template rendering
+
+## 4. Item Loader
+
+- [ ] 4.1 Create `internal/show/item_loader.go` with ItemLoader struct
+- [ ] 4.2 Implement `LoadSpec(specID, projectPath) (*Item, error)` for specs
+- [ ] 4.3 Implement `LoadChange(changeID, projectPath) (*Item, error)` for changes
+- [ ] 4.4 Handle missing files gracefully with clear error messages
+- [ ] 4.5 Combine multiple files for changes (proposal + tasks + design + deltas)
+- [ ] 4.6 Write unit tests with testdata fixtures
+
+## 5. HTTP Server
+
+- [ ] 5.1 Create `internal/show/server.go` with Server struct
+- [ ] 5.2 Implement `StartServer(html, itemDir, projectRoot) (port int, error)` with auto-port
+- [ ] 5.3 Add `GET /` handler serving rendered HTML
+- [ ] 5.4 Add `GET /images/<path>` handler with fallback path resolution
+- [ ] 5.5 Implement graceful shutdown on Ctrl+C (signal handling)
+- [ ] 5.6 Add retry logic for port conflicts (up to 3 attempts)
+- [ ] 5.7 Write integration tests for HTTP routes
+
+## 6. Image Path Resolution
+
+- [ ] 6.1 Implement `resolveImagePath(imagePath, itemDir, projectRoot) string` in server.go
+- [ ] 6.2 Try spec/change directory first (e.g., `spectr/specs/auth/diagram.png`)
+- [ ] 6.3 Fallback to project root (e.g., `./assets/diagram.png`)
+- [ ] 6.4 Return 404 if neither path exists
+- [ ] 6.5 Write unit tests for path resolution with various scenarios
+
+## 7. Browser Opening
+
+- [ ] 7.1 Create `internal/show/browser.go` wrapper for browser opening
+- [ ] 7.2 Implement `OpenBrowser(url string) error` with pkg/browser
+- [ ] 7.3 Print URL to terminal before opening
+- [ ] 7.4 Handle browser opening failures gracefully with fallback message
+- [ ] 7.5 Test on Linux, macOS, and Windows (manual testing)
+
+## 8. CLI Command
+
+- [ ] 8.1 Create `cmd/show.go` with ShowCmd struct
+- [ ] 8.2 Add command flags: `--type` (spec|change) for disambiguation
+- [ ] 8.3 Implement `Run()` method with item type detection
+- [ ] 8.4 Validate item exists before rendering
+- [ ] 8.5 Wire up renderer + server + browser opening flow
+- [ ] 8.6 Add helpful error messages for common issues (item not found, port conflict)
+- [ ] 8.7 Register ShowCmd in `cmd/root.go` CLI struct
+- [ ] 8.8 Write integration tests for show command
+
+## 9. MathJax Integration
+
+- [ ] 9.1 Add MathJax 3.x script tag to HTML template
+- [ ] 9.2 Configure inline math delimiters (`$...$`)
+- [ ] 9.3 Configure display math delimiters (`$$...$$`)
+- [ ] 9.4 Test with sample spec containing math notation
+- [ ] 9.5 Document CDN requirement and offline behavior
+
+## 10. Testing and Validation
+
+- [ ] 10.1 Create testdata fixtures (sample specs and changes with images and math)
+- [ ] 10.2 Write end-to-end test for spec rendering
+- [ ] 10.3 Write end-to-end test for change rendering with tabs
+- [ ] 10.4 Test image resolution (spec-local and project-root)
+- [ ] 10.5 Test MathJax rendering in browser (manual)
+- [ ] 10.6 Test graceful degradation when CDN unreachable
+- [ ] 10.7 Run linter and fix all issues (golangci-lint)
+
+## 11. Documentation
+
+- [ ] 11.1 Add `spectr show` to CLI help text
+- [ ] 11.2 Update README with `spectr show` examples
+- [ ] 11.3 Document image path resolution strategy
+- [ ] 11.4 Document MathJax syntax and limitations
+- [ ] 11.5 Add usage examples to spectr/AGENTS.md if relevant
+
+## 12. Edge Cases and Polish
+
+- [ ] 12.1 Handle missing design.md gracefully (skip tab for changes)
+- [ ] 12.2 Handle empty delta specs (show message instead of empty tab)
+- [ ] 12.3 Add breadcrumb showing item type and ID in HTML header
+- [ ] 12.4 Test with very large specs (>1MB) and add warning if slow
+- [ ] 12.5 Test with Unicode filenames and paths
+- [ ] 12.6 Ensure proper content-type headers for images (PNG, JPG, SVG)


### PR DESCRIPTION
Create comprehensive proposal for a new `spectr show` command that renders specifications and changes in the browser with rich formatting.

Key features:
- Goldmark-based Markdown rendering with GFM extensions
- MathJax 3.x integration for mathematical notation ($...$ and $$...$$)
- Local HTTP server with auto-assigned ports
- Image path resolution (spec/change dir → project root fallback)
- Tabbed interface for changes (Proposal, Tasks, Design, Deltas)
- Cross-platform browser auto-opening
- Clean, readable CSS styling

Files:
- proposal.md: Rationale and impact analysis
- design.md: Technical decisions and architecture
- tasks.md: 71 implementation tasks in 12 sections
- specs/cli-framework/spec.md: CLI command structure deltas
- specs/cli-interface/spec.md: UI and rendering deltas

Stats: 12 requirements, 40 scenarios, 0 breaking changes