### PR TITLE
Add spectral property support

### DIFF
--- a/spectr/changes/replace-regex-with-goldmark/design.md
+++ b/spectr/changes/replace-regex-with-goldmark/design.md
@@ -1,0 +1,346 @@
+# Design: Goldmark AST-Based Parsing
+
+## Context
+
+Spectr currently uses regex-based line scanning for all markdown parsing:
+- Title extraction: scans for first `# ` line
+- Requirement parsing: regex for `### Requirement:`, accumulates lines until next `##`
+- Scenario extraction: regex for `#### Scenario:`
+- Delta sections: regex for `## ADDED|MODIFIED|REMOVED|RENAMED Requirements`
+- Rename pairs: regex for `` - FROM: `### Requirement: X` `` format
+
+This approach works for well-formed documents but fails on edge cases and provides poor error context.
+
+**Stakeholders**: All users relying on validation, archiving, and listing functionality.
+
+**Constraints**:
+- Must maintain backward compatibility with existing spec format
+- Must preserve all existing public APIs (zero breaking changes)
+- Must handle all current test cases plus new edge cases
+- Performance must not regress (ideally improve)
+
+## Goals / Non-Goals
+
+**Goals**:
+1. Replace all regex parsing with goldmark AST traversal
+2. Improve error reporting with precise line:column locations
+3. Handle CommonMark edge cases (code blocks, nested structures)
+4. Single-pass parsing for better performance
+5. Extensible architecture for future spec format enhancements
+
+**Non-Goals**:
+- Changing spec file format or syntax
+- Breaking existing public APIs
+- Implementing custom markdown extensions (use standard CommonMark)
+- Supporting non-CommonMark markdown flavors
+
+## Decisions
+
+### Decision 1: Use Goldmark as AST Provider
+
+**Why Goldmark**:
+- Official Go port of commonmark.js, used by Hugo and many Go projects
+- Complete AST with source position tracking
+- Extensible via renderer and parser plugins
+- Excellent test coverage and active maintenance
+- Zero dependencies beyond stdlib
+
+**Alternatives Considered**:
+- `github.com/gomarkdown/markdown`: Less precise AST, weaker source position tracking
+- `github.com/russross/blackfriday`: Deprecated, no longer maintained
+- Custom parser: High effort, would require extensive testing
+
+**Decision**: Use `github.com/yuin/goldmark v1.7.0+`
+
+### Decision 2: AST Walker Pattern
+
+Implement a generic AST walker that visits nodes and executes callbacks:
+
+```go
+// AST walker signature
+type NodeVisitor func(n ast.Node, entering bool) ast.WalkStatus
+
+// Example usage
+func findH1(doc ast.Node) string {
+    var title string
+    ast.Walk(doc, func(n ast.Node, entering bool) ast.WalkStatus {
+        if heading, ok := n.(*ast.Heading); ok && entering && heading.Level == 1 {
+            title = extractText(heading)
+            return ast.WalkStop
+        }
+        return ast.WalkContinue
+    })
+    return title
+}
+```
+
+**Why**: Goldmark's `ast.Walk` provides idiomatic traversal. Custom walkers add no value.
+
+### Decision 3: Source Position Strategy
+
+Enhance data structures with source position metadata:
+
+```go
+type RequirementBlock struct {
+    HeaderLine string   // Preserved for compatibility
+    Name       string
+    Raw        string
+    SourcePos  *SourcePosition  // NEW: AST-derived position
+}
+
+type SourcePosition struct {
+    StartLine   int
+    StartColumn int
+    EndLine     int
+    EndColumn   int
+}
+```
+
+**Why**: Enables validation errors like `spec.md:42:5: Requirement missing scenario` instead of vague messages.
+
+**Compatibility**: New field is optional, existing code unaffected.
+
+### Decision 4: Delta Section Extraction
+
+Use AST traversal to find `## ADDED Requirements` heading, then collect all nodes until next `##` heading:
+
+```go
+func extractSectionByHeading(doc ast.Node, targetHeading string) []ast.Node {
+    var nodes []ast.Node
+    inSection := false
+
+    ast.Walk(doc, func(n ast.Node, entering bool) ast.WalkStatus {
+        if h, ok := n.(*ast.Heading); ok && entering && h.Level == 2 {
+            text := extractText(h)
+            if strings.Contains(text, targetHeading) {
+                inSection = true
+                return ast.WalkContinue
+            }
+            if inSection {
+                inSection = false
+                return ast.WalkStop
+            }
+        }
+        if inSection && entering {
+            nodes = append(nodes, n)
+        }
+        return ast.WalkContinue
+    })
+
+    return nodes
+}
+```
+
+**Why**: More robust than regex, correctly handles code blocks and nested structures.
+
+### Decision 5: Rename Parsing Strategy
+
+RENAMED sections use non-standard format (bullet lists with inline code):
+
+```markdown
+## RENAMED Requirements
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Strategy**: Use AST to extract list items, then apply targeted regex on list item text:
+
+```go
+func parseRenamedSection(doc ast.Node) []RenameOp {
+    sectionNodes := extractSectionByHeading(doc, "RENAMED Requirements")
+
+    var renamed []RenameOp
+    var currentFrom string
+
+    for _, node := range sectionNodes {
+        if list, ok := node.(*ast.List); ok {
+            // Iterate list items
+            for item := list.FirstChild(); item != nil; item = item.NextSibling() {
+                text := extractText(item)
+                if from := parseFromLine(text); from != "" {
+                    currentFrom = from
+                } else if to := parseToLine(text); to != "" && currentFrom != "" {
+                    renamed = append(renamed, RenameOp{From: currentFrom, To: to})
+                    currentFrom = ""
+                }
+            }
+        }
+    }
+
+    return renamed
+}
+
+func parseFromLine(text string) string {
+    // Targeted regex on clean text (no markdown noise)
+    re := regexp.MustCompile(`^FROM:\s*` + "`" + `###\s+Requirement:\s*(.+?)` + "`" + `$`)
+    matches := re.FindStringSubmatch(strings.TrimSpace(text))
+    if len(matches) > 1 {
+        return matches[1]
+    }
+    return ""
+}
+```
+
+**Why**: Hybrid approach - AST for structure, regex for simple pattern extraction within clean text.
+
+### Decision 6: Line Number Mapping
+
+Goldmark provides `ast.Node.Lines()` which returns `text.Segments` with byte offsets. Convert to line:column:
+
+```go
+func getSourcePosition(node ast.Node, source []byte) *SourcePosition {
+    if node.Lines().Len() == 0 {
+        return nil
+    }
+
+    seg := node.Lines().At(0)
+    startLine := bytes.Count(source[:seg.Start], []byte("\n")) + 1
+    startCol := seg.Start - bytes.LastIndex(source[:seg.Start], []byte("\n"))
+
+    lastSeg := node.Lines().At(node.Lines().Len() - 1)
+    endLine := bytes.Count(source[:lastSeg.Stop], []byte("\n")) + 1
+    endCol := lastSeg.Stop - bytes.LastIndex(source[:lastSeg.Stop], []byte("\n"))
+
+    return &SourcePosition{
+        StartLine:   startLine,
+        StartColumn: startCol,
+        EndLine:     endLine,
+        EndColumn:   endCol,
+    }
+}
+```
+
+**Why**: Accurate source positions for error reporting, consistent with standard editor navigation.
+
+### Decision 7: Backward Compatibility Strategy
+
+**Public API Preservation**:
+- Keep function signatures unchanged (add `*AST` suffix to new implementations initially)
+- Run parallel tests: `regex_output == ast_output` for all existing test cases
+- After validation, replace old implementations, remove `AST` suffix
+- Deprecation: Remove old regex functions entirely (not public API, internal only)
+
+**Data Structure Compatibility**:
+- Add optional fields (`SourcePos *SourcePosition`) that default to nil
+- Existing consumers ignore new fields
+- New consumers can opt-in to enhanced metadata
+
+### Decision 8: Migration Phases
+
+**Phase 1: Foundation** (tasks 1.x)
+- Add goldmark dependency
+- Create AST utility functions
+- Establish testing patterns
+
+**Phase 2: Simple Replacements** (tasks 2.x)
+- Replace title extraction, simple counters
+- Validate equivalence with existing tests
+
+**Phase 3: Complex Parsing** (tasks 3.x-5.x)
+- Migrate requirement and delta parsing
+- Add source position tracking
+- Handle rename edge cases
+
+**Phase 4: Integration** (tasks 6.x-7.x)
+- Update all consumers
+- Remove old implementations
+- Comprehensive validation
+
+**Why Phased**: Reduces risk, allows incremental validation, easier to debug issues.
+
+## Risks / Trade-offs
+
+### Risk 1: Performance Regression
+**Mitigation**: Benchmark before/after. Goldmark's single-pass parsing should be faster than multiple regex scans, but measure to confirm.
+
+### Risk 2: Breaking Changes in Goldmark
+**Mitigation**: Pin to specific version (`v1.7.x`), test upgrades before adopting.
+
+### Risk 3: Edge Cases Not Covered by Tests
+**Mitigation**: Add comprehensive edge case tests (malformed markdown, unusual whitespace, code blocks with fake headers).
+
+### Risk 4: Migration Bugs
+**Mitigation**: Parallel testing (regex vs AST), phased rollout, extensive integration testing before removing old code.
+
+### Trade-off: Added Dependency
+**Accept**: Goldmark is well-maintained, widely used, and critical for correct markdown parsing. Benefits outweigh dependency cost.
+
+## Migration Plan
+
+### Step 1: Add Goldmark Dependency
+```bash
+go get github.com/yuin/goldmark@v1.7.8
+```
+
+### Step 2: Implement AST Utilities
+Create `internal/parsers/ast_utils.go` with:
+- `parseMarkdownToAST(filePath string) (ast.Node, []byte, error)`
+- `extractTextContent(node ast.Node) string`
+- `findHeadingByLevel(doc ast.Node, level int) *ast.Heading`
+- `extractSectionByHeading(doc ast.Node, heading string) []ast.Node`
+- `getSourcePosition(node ast.Node, source []byte) *SourcePosition`
+
+### Step 3: Implement New Parsers
+For each regex parser, create AST equivalent:
+- `ExtractTitleAST()` -> replaces `ExtractTitle()`
+- `ParseRequirementsAST()` -> replaces `ParseRequirements()`
+- `ParseDeltaSpecAST()` -> replaces `ParseDeltaSpec()`
+
+### Step 4: Parallel Testing
+```go
+func TestExtractTitle_Equivalence(t *testing.T) {
+    tests := []string{"testdata/spec1.md", "testdata/spec2.md", ...}
+    for _, path := range tests {
+        regexTitle, _ := ExtractTitle(path)
+        astTitle, _ := ExtractTitleAST(path)
+        assert.Equal(t, regexTitle, astTitle)
+    }
+}
+```
+
+### Step 5: Integration Testing
+Run full test suite:
+```bash
+go test ./...
+go run main.go validate --all --strict
+```
+
+### Step 6: Switchover
+Replace old function calls with new implementations:
+```bash
+# Example
+sed -i 's/ExtractTitle(/ExtractTitleAST(/g' internal/**/*.go
+```
+
+### Step 7: Cleanup
+Remove old regex-based implementations, rename `*AST` functions to original names.
+
+### Rollback Plan
+If issues arise:
+1. Git revert to pre-migration commit
+2. Incremental rollback: Keep new functions, revert consumer updates
+3. Debug in isolation using parallel tests
+
+## Open Questions
+
+1. **Should we expose AST in public API for advanced use cases?**
+   - **Leaning No**: Keep AST as implementation detail, expose only parsed data structures
+   - Can revisit if consumers need direct AST access
+
+2. **How to handle non-CommonMark extensions (if needed in future)?**
+   - **Use goldmark extensions**: Well-supported pattern
+   - Example: Custom renderer for spec-specific syntax
+
+3. **Should source positions be included in JSON output?**
+   - **Leaning Yes**: Helpful for tooling (editors, LSPs)
+   - Make it optional via flag (`--include-positions`)
+
+## Success Criteria
+
+1. ✅ All existing tests pass with AST-based parsing
+2. ✅ New edge case tests pass (code blocks, nested structures)
+3. ✅ `spectr validate --all --strict` passes on entire project
+4. ✅ Performance benchmarks show no regression (ideally improvement)
+5. ✅ Error messages include precise line:column references
+6. ✅ Zero breaking changes to public APIs
+7. ✅ All regex-based parsing code removed from codebase

--- a/spectr/changes/replace-regex-with-goldmark/proposal.md
+++ b/spectr/changes/replace-regex-with-goldmark/proposal.md
@@ -1,0 +1,67 @@
+# Change: Replace Regex Parsing with Goldmark AST
+
+## Why
+
+The current markdown parsing implementation relies heavily on regex patterns and line-by-line scanning, which has several limitations:
+
+1. **Fragility**: Regex patterns are brittle and fail on edge cases like code blocks containing headers, nested structures, or unusual whitespace
+2. **Limited Context**: Line-by-line scanning loses document structure, making it difficult to provide accurate error locations and context
+3. **Maintainability**: Regex patterns are hard to read, test, and extend as spec format evolves
+4. **Performance**: Multiple passes over files for different parsing tasks (titles, requirements, scenarios, deltas)
+
+Goldmark is the canonical Go markdown parser, providing a robust AST (Abstract Syntax Tree) that:
+- Handles all CommonMark edge cases correctly
+- Preserves source positions for accurate error reporting
+- Enables single-pass parsing with complete document structure
+- Supports extensions for custom syntax (delta sections)
+- Maintained by the Go community with comprehensive test coverage
+
+## What Changes
+
+### Core Parsing (Complete Replacement)
+- **Remove**: All regex-based line scanning in `internal/parsers/parsers.go`, `requirement_parser.go`, `delta_parser.go`
+- **Add**: Goldmark dependency (`github.com/yuin/goldmark v1.7.0+`)
+- **Add**: AST walker utilities for extracting titles, requirements, scenarios
+- **Add**: Custom goldmark walker for delta sections (`ADDED`, `MODIFIED`, `REMOVED`, `RENAMED`)
+- **Add**: AST post-processing for rename format (`FROM:`/`TO:` bullets)
+
+### Data Structures (Improved Design)
+- **Enhance** `RequirementBlock`: Add `SourcePos` field with line/column information from AST
+- **Enhance** `DeltaPlan`: Add source location metadata for better error reporting
+- **Add**: `ASTParser` interface for extensibility
+- **Preserve**: Backward compatibility for all public APIs used by archive/validation/list/view
+
+### Affected Capabilities
+- **validation**: Parsing logic changes, error reporting gains AST context (line:column references)
+- **cli-framework**: All parsing functions migrate to goldmark (titles, tasks, requirements, deltas)
+- **archive-workflow**: Requirement merging uses AST-aware comparison for better conflict detection
+
+## Impact
+
+### Breaking Changes
+**None** - All public APIs remain compatible. Internal parsing implementation is fully encapsulated.
+
+### Affected Code
+- `internal/parsers/parsers.go` - Replace `ExtractTitle`, `CountRequirements` with AST-based implementations
+- `internal/parsers/requirement_parser.go` - Replace `ParseRequirements`, `ParseScenarios` with AST traversal
+- `internal/parsers/delta_parser.go` - Replace regex section extraction with AST walking
+- `internal/validation/*` - Update to use enhanced error locations from AST
+- `internal/archive/spec_merger.go` - May leverage AST metadata for better merging
+- `go.mod` - Add goldmark dependency
+
+### Testing Strategy
+- Parallel test execution (regex vs goldmark) during migration to validate equivalence
+- New test cases for goldmark-specific edge cases (code blocks, nested lists, unusual markdown)
+- Performance benchmarks on real spec files to ensure no regression
+- Integration tests with existing validation and archive workflows
+
+### Migration Risk
+**Low** - Changes are internal implementation details. Comprehensive test coverage exists. Phased rollout allows validation at each step.
+
+### Benefits
+1. **Reliability**: Handles all CommonMark edge cases correctly out of the box
+2. **Better Errors**: Precise line:column error locations from AST source positions
+3. **Extensibility**: Easy to add new parsing features using AST traversal
+4. **Performance**: Single-pass parsing replaces multiple regex scans
+5. **Maintainability**: Clear AST traversal code replaces cryptic regex patterns
+6. **Future-Proof**: Built on canonical Go markdown parser with active maintenance

--- a/spectr/changes/replace-regex-with-goldmark/specs/cli-framework/spec.md
+++ b/spectr/changes/replace-regex-with-goldmark/specs/cli-framework/spec.md
@@ -1,0 +1,158 @@
+## MODIFIED Requirements
+
+### Requirement: Title Extraction
+The system SHALL extract titles from proposal and spec markdown files using goldmark AST parsing to find the first level-1 heading and removing "Change:" or "Spec:" prefix if present, correctly handling CommonMark edge cases.
+
+#### Scenario: Extract title from proposal
+- **WHEN** the system reads a `proposal.md` file with heading `# Change: Add Feature`
+- **THEN** it extracts the title as "Add Feature" using AST traversal for H1 nodes
+
+#### Scenario: Extract title from spec
+- **WHEN** the system reads a `spec.md` file with heading `# CLI Framework`
+- **THEN** it extracts the title as "CLI Framework" by finding first H1 in AST
+
+#### Scenario: Fallback to ID when title not found
+- **WHEN** the system cannot extract a title from a markdown file (no H1 nodes in AST)
+- **THEN** it uses the directory name (ID) as the title
+
+#### Scenario: Title in code block ignored
+- **WHEN** a markdown file has `# Title` within a fenced code block before the real title
+- **THEN** the system SHALL ignore the code block content using AST-based parsing
+- **AND** SHALL extract the first structural H1 heading outside code blocks
+
+#### Scenario: Title with inline code and formatting
+- **WHEN** the H1 heading contains inline code or emphasis (e.g., `# Title with \`code\` and **bold**`)
+- **THEN** the system SHALL extract text content from AST nodes
+- **AND** SHALL produce clean title text: "Title with code and bold"
+
+### Requirement: Task Counting
+The system SHALL count tasks in `tasks.md` files by parsing markdown AST to find list items with checkbox patterns `- [ ]` or `- [x]` (case-insensitive), with completed tasks marked by `[x]`.
+
+#### Scenario: Count completed and total tasks
+- **WHEN** the system reads a `tasks.md` file with 3 tasks, 2 marked `[x]` and 1 marked `[ ]`
+- **THEN** it parses the markdown to AST and identifies list items
+- **AND** it reports `taskStatus` as `{ total: 3, completed: 2 }`
+
+#### Scenario: Handle missing tasks file
+- **WHEN** the system cannot find or read a `tasks.md` file for a change
+- **THEN** it reports `taskStatus` as `{ total: 0, completed: 0 }`
+- **AND** continues processing without error
+
+#### Scenario: Nested task lists
+- **WHEN** a `tasks.md` contains nested lists (e.g., sub-tasks indented under main tasks)
+- **THEN** the system SHALL parse using AST to correctly identify all checkbox items
+- **AND** SHALL count both parent and child checkboxes as separate tasks
+- **AND** SHALL handle arbitrary nesting depth
+
+#### Scenario: Tasks in code blocks ignored
+- **WHEN** a `tasks.md` contains checkbox patterns within fenced code blocks
+- **THEN** the system SHALL use AST parsing to distinguish code from structure
+- **AND** SHALL NOT count checkboxes in code blocks as tasks
+- **AND** SHALL only count actual markdown list items with checkboxes
+
+## ADDED Requirements
+
+### Requirement: AST-Based Requirement Parsing
+The system SHALL parse requirement blocks from spec files using goldmark AST traversal to extract requirement headers, scenarios, and content with accurate source position tracking.
+
+#### Scenario: Parse requirements from spec AST
+- **WHEN** the system parses a spec.md file
+- **THEN** it SHALL create goldmark AST from the file content
+- **AND** SHALL traverse AST to find all `### Requirement:` headings (H3 nodes)
+- **AND** SHALL collect requirement content until next H2 or H3 heading
+
+#### Scenario: Extract requirement with scenarios
+- **WHEN** a requirement block contains `#### Scenario:` headings (H4 nodes)
+- **THEN** the system SHALL include all scenario content in the requirement block
+- **AND** SHALL extract scenario names from H4 text content
+- **AND** SHALL preserve scenario bodies including bullet points and paragraphs
+
+#### Scenario: Track source positions
+- **WHEN** parsing requirement blocks from AST
+- **THEN** each RequirementBlock SHALL include SourcePos with start/end line:column
+- **AND** SourcePos SHALL be derived from AST node segment positions
+- **AND** SHALL enable precise error reporting (e.g., "spec.md:42:3: Requirement missing scenario")
+
+#### Scenario: Handle requirements with code blocks
+- **WHEN** a requirement body contains fenced code blocks with pseudo-headers
+- **THEN** AST parsing SHALL correctly treat code as content, not structure
+- **AND** SHALL NOT terminate requirement parsing at fake headers in code
+- **AND** SHALL include entire code block in requirement Raw content
+
+#### Scenario: Handle empty requirements
+- **WHEN** a requirement has no body content (just header followed by next section)
+- **THEN** the system SHALL create RequirementBlock with empty Raw content
+- **AND** SHALL still track SourcePos for the header
+- **AND** SHALL allow validation to detect and report missing content
+
+### Requirement: AST-Based Delta Parsing
+The system SHALL parse delta spec files using goldmark AST to extract ADDED, MODIFIED, REMOVED, and RENAMED delta operations with precise section boundaries.
+
+#### Scenario: Parse delta sections from AST
+- **WHEN** the system parses a delta spec file
+- **THEN** it SHALL create goldmark AST from file content
+- **AND** SHALL find `## ADDED Requirements` heading (H2 node) in AST
+- **AND** SHALL extract all nodes between this heading and next H2 heading
+- **AND** SHALL repeat for MODIFIED, REMOVED, RENAMED sections
+
+#### Scenario: Extract requirements from delta sections
+- **WHEN** processing ADDED or MODIFIED section nodes
+- **THEN** the system SHALL traverse section nodes to find H3 requirement headers
+- **AND** SHALL build RequirementBlock for each with SourcePos metadata
+- **AND** SHALL collect requirement content until next requirement or section boundary
+
+#### Scenario: Parse REMOVED section requirement names
+- **WHEN** processing REMOVED Requirements section
+- **THEN** the system SHALL extract requirement names from H3 headers
+- **AND** SHALL NOT require full requirement bodies or scenarios
+- **AND** SHALL track source positions for removed requirement references
+
+#### Scenario: Parse RENAMED section FROM/TO pairs
+- **WHEN** processing RENAMED Requirements section
+- **THEN** the system SHALL use AST to find list nodes
+- **AND** SHALL extract list item text for FROM and TO patterns
+- **AND** SHALL apply regex to clean text (not raw markdown) for requirement name extraction
+- **AND** SHALL track source positions for each rename pair
+
+#### Scenario: Handle malformed delta sections
+- **WHEN** a delta spec has section headers but no content
+- **THEN** AST parsing SHALL detect empty sections (no H3 descendants)
+- **AND** validation can report meaningful errors with section line numbers
+- **AND** SHALL return empty slices for Added/Modified/Removed as appropriate
+
+### Requirement: AST Utility Functions
+The system SHALL provide reusable AST utility functions in `internal/parsers/ast_utils.go` for common markdown parsing operations.
+
+#### Scenario: Parse markdown file to AST
+- **WHEN** a function needs to parse markdown
+- **THEN** it SHALL call `parseMarkdownToAST(filePath string) (ast.Node, []byte, error)`
+- **AND** the function SHALL read file content and parse with goldmark
+- **AND** SHALL return AST root node and original source bytes
+- **AND** SHALL return error if file cannot be read or parsed
+
+#### Scenario: Extract text content from AST nodes
+- **WHEN** extracting readable text from AST nodes (headings, paragraphs)
+- **THEN** functions SHALL call `extractTextContent(node ast.Node) string`
+- **AND** the function SHALL recursively traverse text nodes
+- **AND** SHALL concatenate all text, stripping markdown formatting
+- **AND** SHALL produce clean human-readable text
+
+#### Scenario: Find headings by level
+- **WHEN** searching for headings of specific level (H1, H2, H3)
+- **THEN** functions SHALL use `findHeadingsByLevel(doc ast.Node, level int) []*ast.Heading`
+- **AND** SHALL traverse AST collecting all heading nodes matching level
+- **AND** SHALL return slice of heading nodes with their positions
+
+#### Scenario: Extract section content by heading
+- **WHEN** extracting content between two section markers
+- **THEN** functions SHALL call `extractSectionByHeading(doc ast.Node, heading string, level int) []ast.Node`
+- **AND** SHALL find target heading by text match at specified level
+- **AND** SHALL collect all nodes until next heading of same or higher level
+- **AND** SHALL return slice of AST nodes representing section content
+
+#### Scenario: Get source position from AST node
+- **WHEN** error reporting needs precise locations
+- **THEN** functions SHALL call `getSourcePosition(node ast.Node, source []byte) *SourcePosition`
+- **AND** SHALL compute line:column from AST segment byte offsets
+- **AND** SHALL return SourcePosition with StartLine, StartColumn, EndLine, EndColumn
+- **AND** SHALL handle multi-line nodes correctly

--- a/spectr/changes/replace-regex-with-goldmark/specs/validation/spec.md
+++ b/spectr/changes/replace-regex-with-goldmark/specs/validation/spec.md
@@ -1,0 +1,121 @@
+## MODIFIED Requirements
+
+### Requirement: Spec File Validation
+The validation system SHALL validate spec files for structural correctness and adherence to Spectr conventions using goldmark AST-based parsing for robust markdown handling and precise error locations.
+
+#### Scenario: Valid spec with all required sections
+- **WHEN** a spec file contains Purpose and Requirements sections with properly formatted requirements and scenarios
+- **THEN** validation SHALL pass with no errors
+- **AND** the validation report SHALL indicate valid=true
+
+#### Scenario: Missing Purpose section
+- **WHEN** a spec file lacks a "## Purpose" section
+- **THEN** validation SHALL fail with an ERROR level issue
+- **AND** the error message SHALL indicate which section is missing with precise line:column location from AST
+- **AND** the error message SHALL include remediation guidance showing correct format
+
+#### Scenario: Missing Requirements section
+- **WHEN** a spec file lacks a "## Requirements" section
+- **THEN** validation SHALL fail with an ERROR level issue
+- **AND** the error message SHALL provide example of correct structure with precise line location
+
+#### Scenario: Requirement without scenarios
+- **WHEN** a requirement exists without any "#### Scenario:" subsections
+- **THEN** validation SHALL report a WARNING level issue with line:column of the requirement header
+- **AND** in strict mode validation SHALL fail (valid=false)
+- **AND** the warning SHALL include example scenario format
+
+#### Scenario: Requirement missing SHALL or MUST
+- **WHEN** a requirement text does not contain "SHALL" or "MUST" keywords
+- **THEN** validation SHALL report a WARNING level issue with precise requirement location
+- **AND** the message SHALL suggest using normative language
+
+#### Scenario: Incorrect scenario format
+- **WHEN** scenarios use formats other than "#### Scenario:" (e.g., bullets or bold text)
+- **THEN** validation SHALL report an ERROR with exact line:column from AST
+- **AND** the message SHALL show the correct "#### Scenario:" header format
+
+#### Scenario: Code blocks containing fake headers
+- **WHEN** a spec file contains code blocks with lines starting with `###` or `####`
+- **THEN** validation SHALL NOT treat these as requirements or scenarios
+- **AND** SHALL correctly parse using AST-based markdown parsing that distinguishes code from structure
+
+#### Scenario: Nested lists in requirements
+- **WHEN** a requirement contains nested bullet lists or numbered lists
+- **THEN** validation SHALL correctly parse the requirement body using AST
+- **AND** SHALL include nested content in the requirement block
+- **AND** SHALL NOT falsely detect list items as new sections
+
+### Requirement: Change Delta Validation
+The validation system SHALL validate change delta specs for structural correctness and delta operation validity using goldmark AST parsing for accurate section extraction.
+
+#### Scenario: Valid change with deltas
+- **WHEN** a change directory contains specs with proper ADDED/MODIFIED/REMOVED/RENAMED sections
+- **THEN** validation SHALL pass with no errors
+- **AND** each delta requirement SHALL be counted toward the total
+
+#### Scenario: Change with no deltas
+- **WHEN** a change directory has no specs/ subdirectory or no delta sections
+- **THEN** validation SHALL fail with an ERROR
+- **AND** the message SHALL explain that at least one delta is required
+- **AND** remediation guidance SHALL explain the delta header format
+
+#### Scenario: Delta sections present but empty
+- **WHEN** delta sections exist (## ADDED Requirements) but contain no requirement entries
+- **THEN** validation SHALL fail with an ERROR
+- **AND** the message SHALL indicate which sections are empty with line location from AST
+- **AND** guidance SHALL explain requirement block format
+
+#### Scenario: ADDED requirement without scenario
+- **WHEN** an ADDED requirement lacks a "#### Scenario:" block
+- **THEN** validation SHALL fail with an ERROR showing precise location
+- **AND** the message SHALL indicate which requirement is missing scenarios
+
+#### Scenario: MODIFIED requirement without scenario
+- **WHEN** a MODIFIED requirement lacks a "#### Scenario:" block
+- **THEN** validation SHALL fail with an ERROR showing requirement line:column
+- **AND** the message SHALL require at least one scenario for MODIFIED requirements
+
+#### Scenario: Duplicate requirement in same section
+- **WHEN** two requirements with the same normalized name appear in the same delta section
+- **THEN** validation SHALL fail with an ERROR showing both line locations from AST
+- **AND** the message SHALL identify the duplicate requirement name with source positions
+
+#### Scenario: Cross-section conflicts
+- **WHEN** a requirement appears in both ADDED and MODIFIED sections
+- **THEN** validation SHALL fail with an ERROR showing line locations of both occurrences
+- **AND** the message SHALL indicate the conflicting requirement and sections
+
+#### Scenario: RENAMED requirement validation
+- **WHEN** a RENAMED section contains well-formed "FROM: X TO: Y" pairs
+- **THEN** validation SHALL accept the renames
+- **AND** SHALL check for duplicate FROM or TO entries
+- **AND** SHALL error if MODIFIED references the old name instead of new name
+
+#### Scenario: Malformed markdown in delta sections
+- **WHEN** delta sections contain malformed markdown (unclosed code blocks, broken links)
+- **THEN** validation SHALL parse using goldmark AST which handles CommonMark edge cases
+- **AND** SHALL extract requirements correctly despite formatting issues
+- **AND** MAY report warnings for markdown quality issues
+
+### Requirement: Helpful Error Messages
+The validation system SHALL provide actionable error messages with remediation guidance and precise source locations derived from goldmark AST node positions.
+
+#### Scenario: Error with remediation steps and source location
+- **WHEN** validation fails due to missing required content
+- **THEN** the error message SHALL explain what is wrong with precise line:column reference
+- **AND** SHALL provide "Next steps" section with concrete actions
+- **AND** SHALL include format examples when applicable
+- **AND** location format SHALL be `path/to/file.md:42:5:` for easy editor navigation
+
+#### Scenario: Ambiguous item name
+- **WHEN** user provides an item name that matches both a change and a spec
+- **THEN** validation SHALL report the ambiguity
+- **AND** SHALL suggest using --type flag to disambiguate
+- **AND** SHALL show available type options (change, spec)
+
+#### Scenario: Item not found with suggestions
+- **WHEN** user provides an item name that does not exist
+- **THEN** validation SHALL report item not found
+- **AND** SHALL provide nearest match suggestions based on string similarity
+- **AND** SHALL limit suggestions to 5 most similar items

--- a/spectr/changes/replace-regex-with-goldmark/tasks.md
+++ b/spectr/changes/replace-regex-with-goldmark/tasks.md
@@ -1,0 +1,57 @@
+# Implementation Tasks
+
+## 1. Foundation
+- [ ] 1.1 Add goldmark dependency to go.mod (`github.com/yuin/goldmark`)
+- [ ] 1.2 Create `internal/parsers/ast_utils.go` with basic AST walker utilities
+- [ ] 1.3 Add helper functions: `walkAST()`, `findHeadings()`, `extractTextContent()`
+- [ ] 1.4 Write unit tests for AST utilities
+
+## 2. Simple Parsers (Titles and Counts)
+- [ ] 2.1 Implement AST-based `ExtractTitleAST()` in parsers.go
+- [ ] 2.2 Implement AST-based `CountRequirementsAST()` in parsers.go
+- [ ] 2.3 Implement AST-based `CountTasksAST()` in parsers.go
+- [ ] 2.4 Write equivalence tests (regex output == AST output for all test cases)
+- [ ] 2.5 Add edge case tests (code blocks with headers, nested lists)
+
+## 3. Requirement Parsing
+- [ ] 3.1 Enhance `RequirementBlock` struct with `SourcePos` field (line, column)
+- [ ] 3.2 Implement AST-based `ParseRequirementsAST()` in requirement_parser.go
+- [ ] 3.3 Implement AST-based `ParseScenariosAST()` in requirement_parser.go
+- [ ] 3.4 Write equivalence tests comparing regex vs AST output
+- [ ] 3.5 Add tests for malformed markdown (missing closing headers, code blocks)
+
+## 4. Delta Section Parsing
+- [ ] 4.1 Enhance `DeltaPlan` struct with source location metadata
+- [ ] 4.2 Implement `parseDeltaSectionAST()` for ADDED/MODIFIED/REMOVED sections
+- [ ] 4.3 Create AST walker for extracting section content by heading
+- [ ] 4.4 Write equivalence tests for delta parsing
+- [ ] 4.5 Add tests for edge cases (empty sections, malformed deltas)
+
+## 5. Rename Parsing (Complex)
+- [ ] 5.1 Implement AST + post-processing for RENAMED section parsing
+- [ ] 5.2 Extract bullet list items with `FROM:` and `TO:` patterns
+- [ ] 5.3 Parse code-fenced requirement names from bullets
+- [ ] 5.4 Write tests for well-formed and malformed rename pairs
+- [ ] 5.5 Add validation for missing FROM or TO in pairs
+
+## 6. Integration and Switchover
+- [ ] 6.1 Replace `ExtractTitle()` calls with `ExtractTitleAST()` across codebase
+- [ ] 6.2 Replace `ParseRequirements()` calls with `ParseRequirementsAST()`
+- [ ] 6.3 Replace `ParseDeltaSpec()` calls with `ParseDeltaSpecAST()`
+- [ ] 6.4 Update validation package to use AST-based error locations
+- [ ] 6.5 Update archive package to leverage AST metadata
+- [ ] 6.6 Remove old regex-based functions once all consumers migrated
+
+## 7. Testing and Validation
+- [ ] 7.1 Run full test suite and ensure all tests pass
+- [ ] 7.2 Run `go run main.go validate --all --strict` on entire project
+- [ ] 7.3 Performance benchmarks: compare regex vs AST parsing time
+- [ ] 7.4 Manual testing: archive a change, validate deltas, view dashboard
+- [ ] 7.5 Update test fixtures if needed for improved error messages
+
+## 8. Documentation and Cleanup
+- [ ] 8.1 Update godoc comments to reflect AST-based implementation
+- [ ] 8.2 Remove unused regex patterns and helper functions
+- [ ] 8.3 Add code examples in comments showing AST traversal
+- [ ] 8.4 Run `golangci-lint` and fix any linting issues
+- [ ] 8.5 Update CHANGELOG or commit messages with migration notes


### PR DESCRIPTION
Created comprehensive Spectr change proposal for migrating from regex-based markdown parsing to goldmark AST traversal.

Why:
- Current regex patterns are fragile and fail on edge cases
- Limited context for error reporting
- Multiple passes over files for different parsing tasks
- Hard to maintain and extend

What:
- Replace all regex line scanning with goldmark AST traversal
- Add goldmark dependency (github.com/yuin/goldmark)
- Enhance data structures with source position metadata
- Improve error reporting with precise line:column locations

Impact:
- Zero breaking changes (internal implementation only)
- Affects: validation, cli-framework, archive-workflow
- 40 implementation tasks across 8 phases
- 8 requirements with 44 scenarios

Deliverables:
- proposal.md: Rationale and impact analysis
- design.md: Technical architecture with 8 key decisions
- tasks.md: 40 phased implementation tasks
- specs/validation/spec.md: 3 MODIFIED requirements
- specs/cli-framework/spec.md: 2 MODIFIED + 3 ADDED requirements