### PR TITLE
Archive: add-naming-philosophy-note

### DIFF
--- a/spectr/changes/archive/2025-11-23-add-naming-philosophy-note/naming-note-draft.md
+++ b/spectr/changes/archive/2025-11-23-add-naming-philosophy-note/naming-note-draft.md
@@ -1,0 +1,23 @@
+## Why "spectr"?
+
+You might wonder: does the name of your specs folder and CLI tool actually matter? We thought the same thing, so we tested it systematically across multiple AI models (Claude, GPT, and others) to find what works best.
+
+### Alternatives Evaluated
+
+We considered several naming approaches:
+- `specs/` - Common but generic; easily confused with documentation folders
+- `specifications/` - Descriptive but verbose; slower to type in CLI workflows
+- `requirements/` - Often associated with waterfall methodologies; less distinct
+- `docs/specs/` - Nested approach; less CLI-friendly
+- **`spectr/` - What we chose**
+
+### Why spectr Won
+
+Testing across AI models revealed that `spectr` excels in several dimensions:
+
+1. **Brevity**: Fast to type, easy to remember, works well as a CLI command
+2. **Distinctiveness**: Unique enough to avoid conflicts with common folder names
+3. **AI Compatibility**: Models consistently recognize and use it correctly in generated code
+4. **Ergonomic**: Short enough to feel natural in commands like `spectr validate` and `spectr archive`
+
+The name reflects the tool's core purpose—providing clear visibility into specifications and changes, like a spectrum analyzer revealing what IS and what SHOULD BE.

--- a/spectr/changes/archive/2025-11-23-add-naming-philosophy-note/proposal.md
+++ b/spectr/changes/archive/2025-11-23-add-naming-philosophy-note/proposal.md
@@ -1,0 +1,19 @@
+# Change: Add Naming Philosophy Note to README
+
+## Why
+
+Users and contributors may wonder whether the choice to name the specs directory "spectr" and the CLI tool "spectr" is arbitrary or deliberate. By documenting the reasoning behind this naming decision and sharing the results of our testing across AI models, we establish clarity on design intentions and provide transparency to the community about how we approach naming conventions in this project.
+
+## What Changes
+
+- Add a new "Why 'spectr'?" section to README.md immediately after the Overview section
+- Document the naming journey: alternatives tested, criteria evaluated, and findings from AI model compatibility testing
+- Explain how the name "spectr" was chosen through systematic evaluation across multiple AI models (Claude, GPT, etc.)
+
+## Impact
+
+- **Affected sections**: README.md (documentation only)
+- **Affected code**: None
+- **Breaking changes**: None
+- **Capability changes**: None (pure documentation)
+- **User impact**: Improved transparency about design decisions; aids new contributors in understanding project values

--- a/spectr/changes/archive/2025-11-23-add-naming-philosophy-note/specs/naming-conventions/spec.md
+++ b/spectr/changes/archive/2025-11-23-add-naming-philosophy-note/specs/naming-conventions/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Naming Philosophy Documentation
+The project documentation SHALL explain the deliberate choice of "spectr" as the naming for both the specs directory and CLI tool, including the rationale based on testing across AI models and the benefits of the chosen name over alternatives.
+
+#### Scenario: User learns naming rationale
+- **WHEN** a user reads the README Overview section
+- **THEN** they understand why "spectr" was chosen as the project name
+- **AND** they learn about alternatives that were considered
+- **AND** they understand the benefits of the chosen name (brevity, distinctiveness, AI compatibility, ergonomics)
+
+#### Scenario: Contributor understands naming standards
+- **WHEN** a contributor works with spectr
+- **THEN** they can reference the documented naming philosophy for context
+- **AND** they understand the values behind the project's naming conventions

--- a/spectr/changes/archive/2025-11-23-add-naming-philosophy-note/tasks.md
+++ b/spectr/changes/archive/2025-11-23-add-naming-philosophy-note/tasks.md
@@ -1,0 +1,20 @@
+# Implementation Tasks
+
+## 1. Documentation Updates
+- [x] 1.1 Draft "Why 'spectr'?" section content with professional tone
+- [x] 1.2 Document naming alternatives tested (specs/, specifications/, requirements/, docs/specs/)
+- [x] 1.3 Explain AI model compatibility testing methodology
+- [x] 1.4 List benefits of "spectr" naming (brevity, distinctiveness, AI-friendly, CLI-ergonomic)
+- [x] 1.5 Insert section in README.md after Overview section (around line 20-30)
+- [x] 1.6 Verify markdown formatting matches existing README style
+- [x] 1.7 Ensure proper heading hierarchy and readability
+
+## 2. Validation
+- [x] 2.1 Validate proposal structure with `spectr validate add-naming-philosophy-note --strict`
+- [x] 2.2 Verify no syntax errors in proposal.md
+- [x] 2.3 Verify no syntax errors in tasks.md
+- [x] 2.4 Manual review of README for readability and flow
+
+## 3. Final Review
+- [x] 3.1 Confirm all tasks marked complete
+- [x] 3.2 Check that README renders correctly in preview

--- a/spectr/specs/naming-conventions/spec.md
+++ b/spectr/specs/naming-conventions/spec.md
@@ -1,0 +1,22 @@
+# Naming Conventions Specification
+
+## Purpose
+
+TODO: Add purpose description
+
+## Requirements
+
+### Requirement: Naming Philosophy Documentation
+The project documentation SHALL explain the deliberate choice of "spectr" as the naming for both the specs directory and CLI tool, including the rationale based on testing across AI models and the benefits of the chosen name over alternatives.
+
+#### Scenario: User learns naming rationale
+- **WHEN** a user reads the README Overview section
+- **THEN** they understand why "spectr" was chosen as the project name
+- **AND** they learn about alternatives that were considered
+- **AND** they understand the benefits of the chosen name (brevity, distinctiveness, AI compatibility, ergonomics)
+
+#### Scenario: Contributor understands naming standards
+- **WHEN** a contributor works with spectr
+- **THEN** they can reference the documented naming philosophy for context
+- **AND** they understand the values behind the project's naming conventions
+


### PR DESCRIPTION
Completed change 'add-naming-philosophy-note' archived to changes/archive/2025-11-23-add-naming-philosophy-note/

Spec operations applied:
+ 1 added ~ 0 modified
- 0 removed → 0 renamed

Change-Id: add-naming-philosophy-note