### PR TITLE
Add proposal version subcommand

### DIFF
--- a/spectr/changes/add-version-subcommand/proposal.md
+++ b/spectr/changes/add-version-subcommand/proposal.md
@@ -1,0 +1,38 @@
+# Change: Add Version Subcommand
+
+## Why
+
+Users and automation systems need a standard way to determine which version of Spectr is installed for troubleshooting, compatibility verification, and dependency management. Currently, there is no built-in command to display version information, forcing users to rely on external methods like checking installation artifacts or git tags.
+
+A version command provides:
+- **Bug reporting**: Users can accurately report which version exhibits issues
+- **Compatibility checking**: Scripts can verify minimum version requirements
+- **Feature availability**: Users can determine if their version supports specific features
+- **CI/CD integration**: Automated pipelines can validate tool versions
+- **Debugging**: Developers can quickly identify the build being used (commit, build date, platform)
+
+## What Changes
+
+- Add `version` subcommand to the CLI that displays version information
+- Support build-time version injection via GoReleaser's ldflags mechanism
+- Display comprehensive build information including:
+  - Version number (from git tags)
+  - Git commit hash (short)
+  - Build date (ISO 8601 format)
+  - Go version used for compilation
+  - OS and architecture
+- Support `--short` flag to output only the version number (for scripting)
+- Support `--json` flag for machine-readable output
+- Integrate with GoReleaser to automatically inject version metadata during builds
+
+## Impact
+
+- **Affected specs**: `cli-interface` (new version command requirement)
+- **Affected code**:
+  - `cmd/root.go`: Add Version field to CLI struct
+  - `cmd/version.go`: New file implementing VersionCmd
+  - `main.go`: Add version variables for ldflags injection
+  - `.goreleaser.yaml`: Add ldflags configuration for version metadata
+- **Breaking changes**: None
+- **Dependencies**: No new dependencies required
+- **Backward compatibility**: Fully backward compatible, purely additive change

--- a/spectr/changes/add-version-subcommand/specs/cli-interface/spec.md
+++ b/spectr/changes/add-version-subcommand/specs/cli-interface/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Version Command
+The CLI SHALL provide a `version` subcommand that displays version and build information to help users identify which version of Spectr they are running.
+
+#### Scenario: User runs version command
+- **WHEN** user runs `spectr version`
+- **THEN** the system displays version information in human-readable format
+- **AND** output includes version number, git commit, build date, Go version, OS, and architecture
+- **AND** the command exits with code 0
+
+#### Scenario: Help text available for version command
+- **WHEN** user runs `spectr version --help`
+- **THEN** the system displays help text explaining the version command and its flags
+- **AND** the help text lists `--short` and `--json` flags
+
+### Requirement: Version Short Output
+The version command SHALL support a `--short` flag that outputs only the version number for use in scripts and automation.
+
+#### Scenario: User requests short version output
+- **WHEN** user runs `spectr version --short`
+- **THEN** the system outputs only the version number (e.g., "v1.2.3" or "dev")
+- **AND** no other information is displayed
+- **AND** output is suitable for parsing in shell scripts
+
+#### Scenario: Short output with piping
+- **WHEN** user runs `spectr version --short` and pipes to another command
+- **THEN** the output contains only the version string with no formatting or colors
+- **AND** the output is a single line with no trailing whitespace except newline
+
+### Requirement: Version JSON Output
+The version command SHALL support a `--json` flag that outputs version information in JSON format for machine consumption.
+
+#### Scenario: User requests JSON version output
+- **WHEN** user runs `spectr version --json`
+- **THEN** the system outputs valid JSON containing all version fields
+- **AND** JSON includes fields: version, commit, date, goVersion, os, arch
+- **AND** JSON is properly formatted and parseable
+
+#### Scenario: JSON output structure validation
+- **WHEN** user parses the JSON output from `spectr version --json`
+- **THEN** each field is a string value
+- **AND** the version field contains the version number
+- **AND** the commit field contains the git commit hash (short form, 7 chars)
+- **AND** the date field contains the build date in ISO 8601 format
+- **AND** the goVersion field contains the Go version (e.g., "go1.25.0")
+- **AND** the os and arch fields contain runtime.GOOS and runtime.GOARCH values
+
+### Requirement: Build-Time Version Injection
+The version command SHALL support version metadata injection at build time via Go linker flags (ldflags), integrated with GoReleaser for release builds.
+
+#### Scenario: GoReleaser injects version metadata
+- **WHEN** Spectr is built via GoReleaser
+- **THEN** the version variable is set to the git tag (e.g., "v1.2.3")
+- **AND** the commit variable is set to the short git commit hash
+- **AND** the date variable is set to the build date in ISO 8601 format
+- **AND** all values are displayed in the version output
+
+#### Scenario: Manual build with ldflags
+- **WHEN** developer builds with `go build -ldflags "-X main.version=v1.0.0"`
+- **THEN** the version command displays the injected version number
+- **AND** other fields display their default or injected values
+
+### Requirement: Development Build Handling
+The version command SHALL gracefully handle cases where version metadata is not injected, displaying "dev" or appropriate defaults.
+
+#### Scenario: Build without ldflags injection
+- **WHEN** user builds Spectr with `go build` without ldflags
+- **THEN** the version command displays "dev" as the version
+- **AND** commit displays "unknown" or empty string
+- **AND** date displays "unknown" or empty string
+- **AND** goVersion displays the runtime Go version
+- **AND** os and arch display the current platform values
+
+#### Scenario: Development build identification
+- **WHEN** user runs version command on a development build
+- **THEN** the output clearly indicates this is a development build
+- **AND** the user understands this is not an official release
+- **AND** the command still exits successfully with code 0
+
+### Requirement: Version Command Integration
+The version command SHALL be integrated into the root CLI structure following the established Kong command pattern used by other subcommands.
+
+#### Scenario: Version command in CLI structure
+- **WHEN** developer examines the CLI struct in `cmd/root.go`
+- **THEN** a Version field of type VersionCmd exists
+- **AND** the field has appropriate Kong tags for help text
+- **AND** the field follows the same pattern as other commands (Init, List, Validate, etc.)
+
+#### Scenario: Version command implementation pattern
+- **WHEN** developer examines `cmd/version.go`
+- **THEN** VersionCmd struct has Short and JSON boolean fields with Kong tags
+- **AND** VersionCmd has a Run() error method
+- **AND** the file includes comprehensive doc comments
+- **AND** the code follows the same patterns as other cmd files

--- a/spectr/changes/add-version-subcommand/tasks.md
+++ b/spectr/changes/add-version-subcommand/tasks.md
@@ -1,0 +1,38 @@
+# Implementation Tasks
+
+## 1. Core Implementation
+- [ ] 1.1 Add version variables to `main.go` (version, commit, date, goVersion)
+- [ ] 1.2 Create `cmd/version.go` implementing VersionCmd struct with flags
+- [ ] 1.3 Implement `Run()` method to display version information
+- [ ] 1.4 Add VersionCmd field to CLI struct in `cmd/root.go`
+- [ ] 1.5 Implement `--short` flag for version-only output
+- [ ] 1.6 Implement `--json` flag for JSON-formatted output
+- [ ] 1.7 Handle "dev" version gracefully when ldflags not provided
+
+## 2. Build Integration
+- [ ] 2.1 Update `.goreleaser.yaml` to inject version metadata via ldflags
+- [ ] 2.2 Test local build with `go build -ldflags` to verify injection
+- [ ] 2.3 Verify GoReleaser builds include correct version information
+- [ ] 2.4 Document build process in code comments
+
+## 3. Testing
+- [ ] 3.1 Create `cmd/version_test.go` with table-driven tests
+- [ ] 3.2 Test default output format (human-readable)
+- [ ] 3.3 Test `--short` flag output
+- [ ] 3.4 Test `--json` flag output and JSON structure
+- [ ] 3.5 Test behavior when version variables are empty/default
+- [ ] 3.6 Add test for Run() method existence (following existing pattern)
+
+## 4. Documentation
+- [ ] 4.1 Add doc comments to VersionCmd struct
+- [ ] 4.2 Add doc comments to Run() method
+- [ ] 4.3 Add usage examples in code comments
+- [ ] 4.4 Ensure `spectr version --help` displays clear help text
+
+## 5. Validation
+- [ ] 5.1 Run `go build` to verify compilation
+- [ ] 5.2 Run `spectr version` to test default output
+- [ ] 5.3 Run `spectr version --short` to verify short output
+- [ ] 5.4 Run `spectr version --json` to verify JSON output
+- [ ] 5.5 Run `go test ./cmd/...` to verify all tests pass
+- [ ] 5.6 Run `golangci-lint run` to verify no linting issues


### PR DESCRIPTION
Add comprehensive proposal for implementing a `spectr version` command that displays version and build information. The proposal includes:

- Rationale for version command (bug reporting, CI/CD, compatibility)
- Support for --short and --json flags
- GoReleaser integration for version metadata injection
- 6 requirements with 12 scenarios covering all use cases
- 27 implementation tasks across core code, build, testing, and docs

Addresses the need for users to identify which version of Spectr they're running for troubleshooting and automation purposes.