### PR TITLE
Add link to spectr-action repository

### DIFF
--- a/spectr/changes/add-spectr-action-link/proposal.md
+++ b/spectr/changes/add-spectr-action-link/proposal.md
@@ -1,0 +1,18 @@
+# Change: Add Spectr Action Documentation Link
+
+## Why
+Users who want to integrate Spectr validation into their CI/CD pipelines need an easy way to discover and use the spectr-action GitHub Action. While the action is already used in this project's CI workflow, there is no user-facing documentation pointing users to the action repository or explaining how to add it to their own projects.
+
+## What Changes
+- Add reference to `connerohnesorge/spectr-action` in README.md Links & Resources section
+- Add brief CI Integration section in README.md explaining how to use the action
+- Update documentation specification to include CI integration documentation requirements
+
+## Impact
+- Affected specs: `documentation`
+- Affected code: `README.md` (Links & Resources section and new CI Integration section)
+- Breaking changes: None
+- Benefits:
+  - Users can easily discover the spectr-action for their own projects
+  - Clear guidance on how to add automated validation to CI pipelines
+  - Improved discoverability of the ecosystem around Spectr

--- a/spectr/changes/add-spectr-action-link/specs/documentation/spec.md
+++ b/spectr/changes/add-spectr-action-link/specs/documentation/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: CI Integration Documentation
+The system SHALL provide documentation explaining how to integrate Spectr validation into CI/CD pipelines using the spectr-action GitHub Action.
+
+#### Scenario: User finds spectr-action repository
+- **WHEN** a user reads the README
+- **THEN** they SHALL find a link to the connerohnesorge/spectr-action repository in the Links & Resources section
+
+#### Scenario: User adds CI validation to their project
+- **WHEN** a user reads the CI Integration section
+- **THEN** they SHALL see a complete example of adding the spectr-action to a GitHub Actions workflow
+- **AND** the example SHALL include the action reference, checkout step, and proper configuration
+
+#### Scenario: User understands CI validation benefits
+- **WHEN** a user reads the CI Integration section
+- **THEN** they SHALL understand that the action provides automated validation on push and pull request events
+- **AND** they SHALL know that it fails fast to provide rapid feedback on specification violations

--- a/spectr/changes/add-spectr-action-link/tasks.md
+++ b/spectr/changes/add-spectr-action-link/tasks.md
@@ -1,0 +1,13 @@
+# Implementation Tasks
+
+## 1. Update README.md
+- [ ] 1.1 Add new "CI Integration" section after "Installation" section
+- [ ] 1.2 Include example GitHub Actions workflow snippet showing spectr-action usage
+- [ ] 1.3 Add link to `connerohnesorge/spectr-action` repository in Links & Resources section
+- [ ] 1.4 Update Table of Contents to include new CI Integration section
+
+## 2. Verification
+- [ ] 2.1 Verify all links are functional and point to correct repositories
+- [ ] 2.2 Ensure markdown formatting is correct
+- [ ] 2.3 Check that code examples use correct action version reference
+- [ ] 2.4 Validate proposal with `spectr validate add-spectr-action-link --strict`


### PR DESCRIPTION
Create change proposal to add documentation about the spectr-action GitHub Action, making it easier for users to integrate automated Spectr validation into their CI/CD pipelines.