### PR TITLE
Spectr app development

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Built with Go
   - [Using Nix Flakes](#using-nix-flakes)
   - [Building from Source](#building-from-source)
   - [Requirements](#requirements)
+- [CI Integration](#ci-integration)
 - [Quick Start](#quick-start)
   - [Initialize a Project](#initialize-a-project)
   - [Create Your First Change](#create-your-first-change)
@@ -143,6 +144,47 @@ mv spectr /usr/local/bin/  # or any directory in your PATH
 - **Go 1.25+** (if building from source)
 - **Nix with flakes enabled** (optional, for Nix installation)
 - **Git** (for project version control)
+
+---
+
+## CI Integration
+
+Spectr can be integrated into your GitHub Actions workflows using [spectr-action](https://github.com/connerohnesorge/spectr-action) to automatically validate specifications and changes on every push or pull request.
+
+### GitHub Actions Example
+
+Add the following to your workflow file (e.g., `.github/workflows/ci.yml`):
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  spectr-validate:
+    name: Validate Specs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate with Spectr
+        uses: connerohnesorge/spectr-action@v1
+```
+
+This workflow will:
+- Run on every push and pull request
+- Check out your repository with full git history
+- Validate all specifications and active changes
+- Fail the build if validation errors are found
+
+For strict validation mode and additional options, see the [spectr-action documentation](https://github.com/connerohnesorge/spectr-action).
 
 ---
 
@@ -1021,6 +1063,7 @@ Periodically, you may:
 ## Links & Resources
 
 - **GitHub Repository**: [github.com/connerohnesorge/spectr](https://github.com/connerohnesorge/spectr)
+- **GitHub Action for CI/CD**: [connerohnesorge/spectr-action](https://github.com/connerohnesorge/spectr-action)
 - **Specification Documentation**: See `spectr/specs/` for detailed capability specs
   - [CLI Interface](spectr/specs/cli-interface/spec.md)
   - [Validation Rules](spectr/specs/validation/spec.md)

--- a/spectr/changes/add-spectr-action-link/tasks.md
+++ b/spectr/changes/add-spectr-action-link/tasks.md
@@ -1,13 +1,13 @@
 # Implementation Tasks
 
 ## 1. Update README.md
-- [ ] 1.1 Add new "CI Integration" section after "Installation" section
-- [ ] 1.2 Include example GitHub Actions workflow snippet showing spectr-action usage
-- [ ] 1.3 Add link to `connerohnesorge/spectr-action` repository in Links & Resources section
-- [ ] 1.4 Update Table of Contents to include new CI Integration section
+- [x] 1.1 Add new "CI Integration" section after "Installation" section
+- [x] 1.2 Include example GitHub Actions workflow snippet showing spectr-action usage
+- [x] 1.3 Add link to `connerohnesorge/spectr-action` repository in Links & Resources section
+- [x] 1.4 Update Table of Contents to include new CI Integration section
 
 ## 2. Verification
-- [ ] 2.1 Verify all links are functional and point to correct repositories
-- [ ] 2.2 Ensure markdown formatting is correct
-- [ ] 2.3 Check that code examples use correct action version reference
-- [ ] 2.4 Validate proposal with `spectr validate add-spectr-action-link --strict`
+- [x] 2.1 Verify all links are functional and point to correct repositories
+- [x] 2.2 Ensure markdown formatting is correct
+- [x] 2.3 Check that code examples use correct action version reference
+- [x] 2.4 Validate proposal with `spectr validate add-spectr-action-link --strict`


### PR DESCRIPTION
Implemented the add-spectr-action-link change proposal:
- Added CI Integration section after Installation in README
- Included GitHub Actions workflow example using spectr-action@v1
- Added spectr-action repository link to Links & Resources
- Updated Table of Contents with new CI Integration entry
- Marked all tasks complete in tasks.md

This makes it easier for users to discover and integrate Spectr validation into their CI/CD pipelines.