### PR TITLE
feat: add version subcommand

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,6 +23,11 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/connerohnesorge/spectr/internal/version.Version={{.Version}}
+      - -X github.com/connerohnesorge/spectr/internal/version.Commit={{.Commit}}
+      - -X github.com/connerohnesorge/spectr/internal/version.Date={{.Date}}
 
 archives:
   - formats: [tar.gz]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,4 +11,5 @@ type CLI struct {
 	Validate ValidateCmd        `cmd:"" help:"Validate changes or specs"`
 	Archive  archive.ArchiveCmd `cmd:"" help:"Archive a completed change"`
 	View     ViewCmd            `cmd:"" help:"Display project dashboard"`
+	Version  VersionCmd         `cmd:"" help:"Show version and build info"`
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,60 @@
+// Package cmd provides command-line interface implementations for Spectr.
+// This file contains the version command for displaying build information.
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/connerohnesorge/spectr/internal/version"
+)
+
+// VersionCmd represents the version command which displays build information
+// including version number, git commit hash, and build date.
+//
+// Output formats:
+//   - Default: Multi-line formatted output with version, commit, and date
+//   - --short: Version number only (e.g., "v0.1.0")
+//   - --json: Machine-readable JSON for automation and scripting
+//
+// Examples:
+//
+//	spectr version              # Full build information
+//	spectr version --short      # Version number only
+//	spectr version --json       # JSON format
+type VersionCmd struct {
+	// JSON enables JSON output format for scripting and automation.
+	// When enabled, outputs structured data with version, commit, date.
+	JSON bool `kong:"help='Output in JSON format for scripting'"`
+
+	// Short enables minimal output showing only the version number.
+	// Useful for scripts that need to parse or compare version numbers.
+	Short bool `kong:"help='Output version number only'"`
+}
+
+// Run executes the version command.
+// It retrieves build information and formats the output based on the flags:
+// JSON flag takes precedence over Short flag if both are set.
+// Returns an error if JSON marshaling fails, nil otherwise.
+func (c *VersionCmd) Run() error {
+	// Get build information
+	info := version.GetBuildInfo()
+
+	// Format output based on flags
+	switch {
+	case c.JSON:
+		// JSON format for machine consumption
+		jsonBytes, err := info.JSON()
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(jsonBytes))
+	case c.Short:
+		// Short format: version number only
+		fmt.Println(info.Short())
+	default:
+		// Default format: multi-line with all build info
+		fmt.Println(info.String())
+	}
+
+	return nil
+}

--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,9 @@ nix fmt
             reftools
             goreleaser
             vhs
+
+            # For docs site
+            biome
           ]
           ++ builtins.attrValues scriptPackages;
       };
@@ -180,11 +183,16 @@ nix fmt
       };
 
       packages = {
-        default = pkgs.buildGoModule {
+        default = pkgs.buildGoModule rec {
           pname = "spectr";
           version = "0.0.1";
           src = self;
           vendorHash = "sha256-6bE9HNbebJ4ivHF7YynZwL6mu+T3wEfESjQdyR8q59M=";
+          ldflags = [
+            "-s"
+            "-w"
+            "-X github.com/connerohnesorge/spectr/internal/version.Version=${version}"
+          ];
           meta = with pkgs.lib; {
             description = "A CLI tool for spec-driven development workflow with change proposals, validation, and archiving";
             homepage = "https://github.com/connerohnesorge/spectr";

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,55 @@
+// Package version provides build information for the spectr binary.
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Build information variables set via ldflags during compilation.
+// Example: go build -ldflags
+// "-X github.com/connerohnesorge/spectr/internal/version.Version=v0.1.0"
+var (
+	// Version is the semantic version of the build.
+	Version = "dev"
+
+	// Commit is the git commit hash of the build.
+	Commit = "unknown"
+
+	// Date is the timestamp when the binary was built.
+	Date = "unknown"
+)
+
+// BuildInfo contains version and build metadata.
+type BuildInfo struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+}
+
+// GetBuildInfo returns the current build information.
+func GetBuildInfo() BuildInfo {
+	return BuildInfo{
+		Version: Version,
+		Commit:  Commit,
+		Date:    Date,
+	}
+}
+
+// String returns a formatted multi-line representation of build info.
+func (b BuildInfo) String() string {
+	return fmt.Sprintf("Version:  %s\nCommit:   %s\nDate:     %s",
+		b.Version,
+		b.Commit,
+		b.Date)
+}
+
+// JSON returns the build info as JSON bytes.
+func (b BuildInfo) JSON() ([]byte, error) {
+	return json.Marshal(b)
+}
+
+// Short returns just the version string.
+func (b BuildInfo) Short() string {
+	return b.Version
+}

--- a/spectr/changes/add-version-subcommand/proposal.md
+++ b/spectr/changes/add-version-subcommand/proposal.md
@@ -1,0 +1,24 @@
+# Change: Add Version Subcommand
+
+## Why
+
+Users need to verify which version of spectr they have installed, especially when troubleshooting issues or checking compatibility. The version information must work correctly whether installed via goreleaser releases (which inject version at build time via ldflags) or via nix flake (which uses the flake.nix version attribute).
+
+## What Changes
+
+- Add `spectr version` subcommand to display version, commit, and build date
+- Create `internal/version` package with version variables that can be set via ldflags
+- Update `.goreleaser.yaml` to inject version information at build time
+- Update `flake.nix` to inject version information via ldflags
+- Support `--json` flag for machine-readable version output
+- Support `--short` flag for version number only output
+
+## Impact
+
+- Affected specs: `specs/cli-framework/spec.md`
+- Affected code:
+  - `cmd/root.go` - add VersionCmd field
+  - `cmd/version.go` - new file for version command
+  - `internal/version/version.go` - new package for version variables
+  - `.goreleaser.yaml` - add ldflags configuration
+  - `flake.nix` - add ldflags to buildGoModule

--- a/spectr/changes/add-version-subcommand/specs/cli-framework/spec.md
+++ b/spectr/changes/add-version-subcommand/specs/cli-framework/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Version Command Structure
+The CLI SHALL provide a `version` command that displays version information including version number, git commit hash, and build date.
+
+#### Scenario: Version command registration
+- **WHEN** the CLI is initialized
+- **THEN** it SHALL include a VersionCmd struct field tagged with `cmd`
+- **AND** the command SHALL be accessible via `spectr version`
+- **AND** help text SHALL describe version display functionality
+
+#### Scenario: Version command invocation
+- **WHEN** user runs `spectr version` without flags
+- **THEN** the system displays version in format: `spectr version {version} (commit: {commit}, built: {date})`
+- **AND** version SHALL be the semantic version (e.g., `0.1.0` or `dev`)
+- **AND** commit SHALL be the git commit hash (short or full) or `unknown`
+- **AND** date SHALL be the build date in ISO 8601 format or `unknown`
+
+#### Scenario: Version command with short flag
+- **WHEN** user runs `spectr version --short`
+- **THEN** the system displays only the version number (e.g., `0.1.0`)
+- **AND** no other information is displayed
+
+#### Scenario: Version command with JSON flag
+- **WHEN** user runs `spectr version --json`
+- **THEN** the system outputs version data as JSON
+- **AND** JSON SHALL include fields: `version`, `commit`, `date`
+- **AND** SHALL be parseable by standard JSON tools
+
+### Requirement: Version Variable Injection
+The version information SHALL be injectable at build time via Go ldflags, supporting both goreleaser releases and nix flake builds.
+
+#### Scenario: Goreleaser version injection
+- **WHEN** goreleaser builds the binary
+- **THEN** version SHALL be set from git tag via ldflags
+- **AND** commit SHALL be set from git commit hash via ldflags
+- **AND** date SHALL be set from build timestamp via ldflags
+
+#### Scenario: Nix flake version injection
+- **WHEN** nix builds the binary via flake.nix
+- **THEN** version SHALL be set from the flake package version attribute via ldflags
+- **AND** commit and date MAY be `unknown` if not available in nix build context
+
+#### Scenario: Development build defaults
+- **WHEN** binary is built without ldflags (e.g., `go build`)
+- **THEN** version SHALL default to `dev`
+- **AND** commit SHALL default to `unknown`
+- **AND** date SHALL default to `unknown`
+
+### Requirement: Version Package Location
+The version variables SHALL be defined in a dedicated `internal/version` package for clean separation and easy ldflags targeting.
+
+#### Scenario: Package structure
+- **WHEN** the version package is imported
+- **THEN** it SHALL expose `Version`, `Commit`, and `Date` string variables
+- **AND** variables SHALL have default values for development builds
+- **AND** the ldflags path SHALL be `github.com/connerohnesorge/spectr/internal/version`

--- a/spectr/changes/add-version-subcommand/tasks.md
+++ b/spectr/changes/add-version-subcommand/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 Create `internal/version/version.go` with version, commit, and date variables
+- [x] 1.2 Create `cmd/version.go` with VersionCmd struct and Run method
+- [x] 1.3 Add VersionCmd field to CLI struct in `cmd/root.go`
+- [x] 1.4 Update `.goreleaser.yaml` to inject ldflags for version, commit, and date
+- [x] 1.5 Update `flake.nix` to inject ldflags for version in buildGoModule
+
+## 2. Testing
+
+- [x] 2.1 Verify `spectr version` displays version information
+- [x] 2.2 Verify `spectr version --json` outputs valid JSON
+- [x] 2.3 Verify `spectr version --short` outputs only version number
+- [x] 2.4 Verify goreleaser builds inject version correctly (via dry run)
+- [x] 2.5 Verify nix build injects version correctly


### PR DESCRIPTION
## Summary
- Add `spectr version` subcommand to display version, commit hash, and build date
- Support `--json` flag for machine-readable output and `--short` flag for version number only
- Configure goreleaser to inject full build info (version, commit, date) via ldflags
- Configure nix flake to inject version via ldflags

## Test plan
- [x] Verify `spectr version` displays version information
- [x] Verify `spectr version --json` outputs valid JSON
- [x] Verify `spectr version --short` outputs only version number
- [x] Verify goreleaser builds inject version correctly (via dry run)
- [x] Verify nix build injects version correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `version` subcommand to display application version and build information including version number, commit hash, and build date.
  * Supports multiple output formats: default human-readable display, `--short` for version string only, and `--json` for machine-readable JSON output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->