### PR TITLE
Fix standard command paths to stay POSIX

### DIFF
--- a/internal/init/providers/constants.go
+++ b/internal/init/providers/constants.go
@@ -1,6 +1,6 @@
 package providers
 
-import "path/filepath"
+import "path"
 
 // Priority constants for all providers.
 // Lower numbers = higher priority (displayed first).
@@ -57,9 +57,9 @@ func StandardFrontmatter() map[string]string {
 func StandardCommandPaths(
 	dir, ext string,
 ) (proposalPath, archivePath, applyPath string) {
-	proposalPath = filepath.Join(dir, "spectr-proposal"+ext)
-	archivePath = filepath.Join(dir, "spectr-archive"+ext)
-	applyPath = filepath.Join(dir, "spectr-apply"+ext)
+	proposalPath = path.Join(dir, "spectr-proposal"+ext)
+	archivePath = path.Join(dir, "spectr-archive"+ext)
+	applyPath = path.Join(dir, "spectr-apply"+ext)
 
 	return proposalPath, archivePath, applyPath
 }


### PR DESCRIPTION
## Summary
- use path.Join to keep generated command paths using forward slashes across platforms
- maintain compatibility with provider tests

## Testing
- GOCACHE=/home/connerohnesorge/Documents/001Repos/spectr/.gocache go test ./internal/init/providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization with no user-visible changes or impact on functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->