### PR TITLE
Add help toggle hotkey (?) to TUI

### DIFF
--- a/spectr/changes/add-help-hotkey/proposal.md
+++ b/spectr/changes/add-help-hotkey/proposal.md
@@ -1,0 +1,15 @@
+# Change: Show Hotkeys Only on '?' Keypress
+
+## Why
+The current TUI displays all hotkeys at all times in the help text, which takes up screen real estate and adds visual clutter. Users familiar with the interface don't need to see `↑/↓/j/k: navigate | Enter: copy ID | e: edit | a: archive | q: quit` on every screen. A common pattern in terminal applications (like vim, less, htop) is to show a minimal footer and reveal the full help on demand via `?`.
+
+## What Changes
+- Remove inline hotkey display from the default TUI view
+- Show only a minimal footer with item count, project path, and a hint: `?: help`
+- Add `?` hotkey that toggles display of the full hotkey reference
+- When help is shown, display all available hotkeys in the footer area
+- Pressing `?` again (or any navigation key) hides the help and returns to minimal footer
+
+## Impact
+- Affected specs: cli-interface
+- Affected code: internal/tui/table.go, internal/list/interactive.go, internal/list/interactive_test.go

--- a/spectr/changes/add-help-hotkey/specs/cli-interface/spec.md
+++ b/spectr/changes/add-help-hotkey/specs/cli-interface/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Help Toggle Hotkey
+The interactive TUI modes SHALL hide hotkey hints by default and reveal them only when the user presses `?`, reducing visual clutter while maintaining discoverability.
+
+#### Scenario: Default view shows minimal footer
+- **WHEN** user enters any interactive TUI mode (list, archive, validate)
+- **THEN** the footer displays only: item count, project path, and `?: help`
+- **AND** the full hotkey reference is NOT shown
+- **AND** navigation and all other hotkeys remain functional
+
+#### Scenario: User presses '?' to reveal help
+- **WHEN** user presses `?` while in interactive mode
+- **THEN** the full hotkey reference is displayed in the footer area
+- **AND** the reference includes all available hotkeys for the current mode
+- **AND** the view updates immediately
+
+#### Scenario: User dismisses help by pressing '?' again
+- **WHEN** user presses `?` while help is visible
+- **THEN** the help is hidden
+- **AND** the minimal footer is restored
+
+#### Scenario: Help auto-hides on navigation
+- **WHEN** user presses a navigation key (↑/↓/j/k) while help is visible
+- **THEN** the help is automatically hidden
+- **AND** the navigation action is performed
+- **AND** the minimal footer is restored
+
+#### Scenario: Help content matches mode
+- **WHEN** help is displayed in changes mode
+- **THEN** the help shows: `↑/↓/j/k: navigate | Enter: copy ID | e: edit | a: archive | q: quit`
+- **WHEN** help is displayed in specs mode
+- **THEN** the help shows: `↑/↓/j/k: navigate | Enter: copy ID | e: edit | q: quit`
+- **WHEN** help is displayed in unified mode
+- **THEN** the help shows: `↑/↓/j/k: navigate | Enter: copy ID | e: edit | a: archive | t: filter | q: quit`
+
+## MODIFIED Requirements
+
+### Requirement: Interactive List Mode
+The interactive list mode in `spectr list` is extended to support unified display of changes and specifications alongside existing separate modes.
+
+#### Previous behavior
+The system displays either changes OR specs in interactive mode based on the `--specs` flag. Columns and behavior are specific to each item type.
+
+#### New behavior
+- When `--all` is provided with `--interactive`, both changes and specs are shown together with unified columns
+- When neither `--all` nor `--specs` are provided, changes-only mode is default (backward compatible)
+- When `--specs` is provided without `--all`, specs-only mode is used (backward compatible)
+- Each item type is clearly labeled in the Type column (CHANGE or SPEC)
+- Type-aware actions apply based on selected item (edit only for specs)
+
+#### Scenario: Default behavior unchanged
+- **WHEN** the user runs `spectr list --interactive`
+- **THEN** the behavior is identical to before this change
+- **AND** only changes are displayed
+- **AND** columns show: ID, Title, Deltas, Tasks
+
+#### Scenario: Unified mode opt-in
+- **WHEN** the user explicitly uses `--all --interactive`
+- **THEN** the new unified behavior is enabled
+- **AND** users must opt-in to the new functionality
+- **AND** columns show: Type, ID, Title, Details (context-aware)
+
+#### Scenario: Unified mode displays both types
+- **WHEN** unified mode is active
+- **THEN** changes show Type="CHANGE" with delta and task counts
+- **AND** specs show Type="SPEC" with requirement counts
+- **AND** both types are navigable and selectable in the same table
+
+#### Scenario: Type-specific actions in unified mode
+- **WHEN** user presses 'e' on a change row in unified mode
+- **THEN** the action is ignored (no edit for changes)
+- **AND** help text does not show 'e' option
+- **WHEN** user presses 'e' on a spec row in unified mode
+- **THEN** the spec opens in the editor as usual
+
+#### Scenario: Help text uses minimal footer by default
+- **WHEN** interactive mode is displayed in any mode (changes, specs, or unified)
+- **THEN** the footer shows: item count, project path, and `?: help`
+- **AND** the full hotkey reference is hidden until `?` is pressed
+
+#### Scenario: Help text format for changes mode
+- **WHEN** user presses `?` in changes mode (`spectr list -I`)
+- **THEN** the help shows: `↑/↓/j/k: navigate | Enter: copy ID | e: edit | a: archive | q: quit`
+- **AND** pressing `?` again or navigating hides the help
+
+#### Scenario: Help text format for specs mode
+- **WHEN** user presses `?` in specs mode (`spectr list --specs -I`)
+- **THEN** the help shows: `↑/↓/j/k: navigate | Enter: copy ID | e: edit | q: quit`
+- **AND** archive hotkey is NOT shown (specs cannot be archived)

--- a/spectr/changes/add-help-hotkey/tasks.md
+++ b/spectr/changes/add-help-hotkey/tasks.md
@@ -1,0 +1,31 @@
+## 1. Core Implementation
+
+- [ ] 1.1 Add `showHelp` boolean field to `TablePicker` struct in `internal/tui/table.go`
+- [ ] 1.2 Add `?` key handler in `TablePicker.Update()` to toggle `showHelp` state
+- [ ] 1.3 Create `generateMinimalFooter()` method that shows only item count, project path, and `?: help` hint
+- [ ] 1.4 Modify `generateHelpText()` to be the full help text (existing implementation)
+- [ ] 1.5 Update `View()` to show minimal footer by default, full help when `showHelp` is true
+- [ ] 1.6 Auto-hide help on navigation keys (↑/↓/j/k) to return to minimal view
+
+## 2. Interactive Model Updates
+
+- [ ] 2.1 Add `showHelp` field to `interactiveModel` in `internal/list/interactive.go`
+- [ ] 2.2 Add `?` key handler in `interactiveModel.Update()` to toggle help display
+- [ ] 2.3 Update `View()` to conditionally show minimal or full help text
+- [ ] 2.4 Update `rebuildUnifiedTable()` to preserve help toggle state
+- [ ] 2.5 Auto-hide help on navigation keys to avoid cluttering view
+
+## 3. Testing
+
+- [ ] 3.1 Add test for `?` key toggling help visibility in TablePicker
+- [ ] 3.2 Add test for minimal footer content (item count, project path, `?: help`)
+- [ ] 3.3 Add test for full help content when help is shown
+- [ ] 3.4 Add test for auto-hide on navigation keys
+- [ ] 3.5 Add test for help toggle in interactiveModel
+
+## 4. Validation
+
+- [ ] 4.1 Run `go test ./...` to verify all tests pass
+- [ ] 4.2 Manual test: verify `spectr list -I` shows minimal footer
+- [ ] 4.3 Manual test: verify pressing `?` reveals full hotkey list
+- [ ] 4.4 Manual test: verify pressing `?` again or navigating hides help


### PR DESCRIPTION
## Summary
- Proposes showing hotkeys only when pressing `?` inside the TUI
- Default view shows minimal footer: item count, project path, `?: help`
- Pressing `?` toggles full hotkey reference, auto-hides on navigation

## Motivation
The current TUI displays all hotkeys at all times, taking up screen real estate and adding visual clutter. This follows common terminal app patterns (vim, less, htop) of showing minimal info by default.

## Test plan
- [ ] Review proposal.md for completeness
- [ ] Review spec delta for scenario coverage
- [ ] Review tasks.md for implementation completeness
- [ ] Validate with `spectr validate add-help-hotkey --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)