### PR TITLE
docs: remove incorrect spectr show command references

### DIFF
--- a/.agent/workflows/spectr-apply.md
+++ b/.agent/workflows/spectr-apply.md
@@ -14,10 +14,11 @@ Track these steps as TODOs and complete them one by one.
 2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
 3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
 4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
-5. Reference `spectr list` or `spectr show <item>` when additional context is required.
+5. Reference `spectr list` when additional context is required.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+- Read `spectr/changes/<id>/proposal.md` for proposal details.
+- Read `spectr/changes/<id>/specs/<capability>/spec.md` for delta specs.
 
 <!-- spectr:END -->
 

--- a/.agent/workflows/spectr-proposal.md
+++ b/.agent/workflows/spectr-proposal.md
@@ -19,7 +19,8 @@ description: Scaffold a new Spectr change and validate strictly.
 7. Validate with `spectr validate <id> --strict` and resolve every issue before sharing the proposal.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` or `spectr show <spec> --type spec` to inspect details when validation fails.
+- Read delta specs directly at `spectr/changes/<id>/specs/<capability>/spec.md` when validation fails.
+- Read existing specs at `spectr/specs/<capability>/spec.md` to understand current state.
 - Search existing requirements with `rg -n "Requirement:|Scenario:" spectr/specs` before writing new ones.
 - Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
 

--- a/.agent/workflows/spectr-sync.md
+++ b/.agent/workflows/spectr-sync.md
@@ -36,7 +36,7 @@ description: Detect spec drift from code and update specs interactively.
    - Show summary of changes made.
 
 ### Reference
-- Use `spectr show <spec> --type spec` to view current spec content.
+- Read `spectr/specs/<capability>/spec.md` to view current spec content.
 - Search code with `rg` to find implementations.
 - Validate after edits with `spectr validate --strict`.
 

--- a/.claude/commands/spectr/apply.md
+++ b/.claude/commands/spectr/apply.md
@@ -16,9 +16,10 @@ Track these steps as TODOs and complete them one by one.
 2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
 3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
 4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
-5. Reference `spectr list` or `spectr show <item>` when additional context is required.
+5. Reference `spectr list` when additional context is required.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+- Read `spectr/changes/<id>/proposal.md` for proposal details.
+- Read `spectr/changes/<id>/specs/<capability>/spec.md` for delta specs.
 
 <!-- spectr:END -->

--- a/.claude/commands/spectr/proposal.md
+++ b/.claude/commands/spectr/proposal.md
@@ -21,7 +21,8 @@ tags: [spectr, change]
 7. Validate with `spectr validate <id> --strict` and resolve every issue before sharing the proposal.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` or `spectr show <spec> --type spec` to inspect details when validation fails.
+- Read delta specs directly at `spectr/changes/<id>/specs/<capability>/spec.md` when validation fails.
+- Read existing specs at `spectr/specs/<capability>/spec.md` to understand current state.
 - Search existing requirements with `rg -n "Requirement:|Scenario:" spectr/specs` before writing new ones.
 - Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
 

--- a/.claude/commands/spectr/sync.md
+++ b/.claude/commands/spectr/sync.md
@@ -38,7 +38,7 @@ tags: [spectr, sync]
    - Show summary of changes made.
 
 **Reference**
-- Use `spectr show <spec> --type spec` to view current spec content.
+- Read `spectr/specs/<capability>/spec.md` to view current spec content.
 - Search code with `rg` to find implementations.
 - Validate after edits with `spectr validate --strict`.
 

--- a/.gemini/commands/spectr-apply.toml
+++ b/.gemini/commands/spectr-apply.toml
@@ -12,9 +12,10 @@ Track these steps as TODOs and complete them one by one.
 2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
 3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
 4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
-5. Reference `spectr list` or `spectr show <item>` when additional context is required.
+5. Reference `spectr list` when additional context is required.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+- Read `spectr/changes/<id>/proposal.md` for proposal details.
+- Read `spectr/changes/<id>/specs/<capability>/spec.md` for delta specs.
 
 """

--- a/.gemini/commands/spectr-archive.toml
+++ b/.gemini/commands/spectr-archive.toml
@@ -12,10 +12,10 @@ prompt = """
    - If the conversation references a change loosely (for example by title or summary), run `spectr list` to surface likely IDs, share the relevant candidates, and confirm which one the user intends.
    - Otherwise, review the conversation, run `spectr list`, and ask the user which change to archive; wait for a confirmed change ID before proceeding.
    - If you still cannot identify a single change ID, stop and tell the user you cannot archive anything yet.
-2. Validate the change ID by running `spectr list` (or `spectr show <id>`) and stop if the change is missing, already archived, or otherwise not ready to archive.
+2. Validate the change ID by running `spectr list` and stop if the change is missing, already archived, or otherwise not ready to archive.
 3. Run `spectr archive <id> --yes` so the CLI moves the change and applies spec updates without prompts.
 4. Review the command output to confirm the target specs were updated and the change landed in `spectr/changes/archive/`.
-5. Validate with `spectr validate --strict` and inspect with `spectr show <id>` if anything looks off.
+5. Validate with `spectr validate --strict` and read `spectr/changes/<id>/proposal.md` if anything looks off.
 
 **Reference**
 - Use `spectr list` to confirm change IDs before archiving.

--- a/.gemini/commands/spectr-proposal.toml
+++ b/.gemini/commands/spectr-proposal.toml
@@ -17,7 +17,8 @@ prompt = """
 7. Validate with `spectr validate <id> --strict` and resolve every issue before sharing the proposal.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` or `spectr show <spec> --type spec` to inspect details when validation fails.
+- Read delta specs directly at `spectr/changes/<id>/specs/<capability>/spec.md` when validation fails.
+- Read existing specs at `spectr/specs/<capability>/spec.md` to understand current state.
 - Search existing requirements with `rg -n \"Requirement:|Scenario:\" spectr/specs` before writing new ones.
 - Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
 

--- a/.gemini/commands/spectr/apply.toml
+++ b/.gemini/commands/spectr/apply.toml
@@ -12,9 +12,10 @@ Track these steps as TODOs and complete them one by one.
 2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
 3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
 4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
-5. Reference `spectr list` or `spectr show <item>` when additional context is required.
+5. Reference `spectr list` when additional context is required.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+- Read `spectr/changes/<id>/proposal.md` for proposal details.
+- Read `spectr/changes/<id>/specs/<capability>/spec.md` for delta specs.
 
 """

--- a/.gemini/commands/spectr/proposal.toml
+++ b/.gemini/commands/spectr/proposal.toml
@@ -17,7 +17,8 @@ prompt = """
 7. Validate with `spectr validate <id> --strict` and resolve every issue before sharing the proposal.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` or `spectr show <spec> --type spec` to inspect details when validation fails.
+- Read delta specs directly at `spectr/changes/<id>/specs/<capability>/spec.md` when validation fails.
+- Read existing specs at `spectr/specs/<capability>/spec.md` to understand current state.
 - Search existing requirements with `rg -n \"Requirement:|Scenario:\" spectr/specs` before writing new ones.
 - Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
 

--- a/.gemini/commands/spectr/sync.toml
+++ b/.gemini/commands/spectr/sync.toml
@@ -34,7 +34,7 @@ prompt = """
    - Show summary of changes made.
 
 **Reference**
-- Use `spectr show <spec> --type spec` to view current spec content.
+- Read `spectr/specs/<capability>/spec.md` to view current spec content.
 - Search code with `rg` to find implementations.
 - Validate after edits with `spectr validate --strict`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,15 +76,15 @@ After deployment, create separate PR to:
 **Before Creating Specs:**
 - Always check if capability already exists
 - Prefer modifying existing specs over creating duplicates
-- Use `spectr show [spec]` to review current state
+- Read `spectr/specs/<capability>/spec.md` directly to review current state
 - If request is ambiguous, ask 1–2 clarifying questions before scaffolding
 
 ### Search Guidance
 - Enumerate specs: `spectr spec list --long` (or `--json` for scripts)
 - Enumerate changes: `spectr list` (or `spectr change list --json` - deprecated but available)
-- Show details:
-  - Spec: `spectr show <spec-id> --type spec` (use `--json` for filters)
-  - Change: `spectr show <change-id> --json --deltas-only`
+- Read details directly:
+  - Spec: Read `spectr/specs/<capability>/spec.md`
+  - Change: Read `spectr/changes/<change-id>/proposal.md`
 - Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" spectr/specs`
 
 ## Quick Start
@@ -95,7 +95,6 @@ After deployment, create separate PR to:
 # Essential commands
 spectr list                  # List active changes
 spectr list --specs          # List specifications
-spectr show [item]           # Display change or spec
 spectr validate [item]       # Validate changes or specs
 spectr archive <change-id> [--yes|-y]   # Archive after deployment (add --yes for non-interactive runs)
 
@@ -104,13 +103,16 @@ spectr init [path]           # Initialize Spectr
 spectr update [path]         # Update instruction files
 
 # Interactive mode
-spectr show                  # Prompts for selection
 spectr validate              # Bulk validation mode
 
 # Debugging
-spectr show [change] --json --deltas-only
 spectr validate [change] --strict
 ```
+
+**Reading Specs and Changes (for AI agents):**
+- Specs: Read `spectr/specs/<capability>/spec.md` directly
+- Changes: Read `spectr/changes/<change-id>/proposal.md` directly
+- Tasks: Read `spectr/changes/<change-id>/tasks.md` directly
 
 ### Command Flags
 
@@ -301,20 +303,18 @@ Example for RENAMED:
 
 **Silent scenario parsing failures**
 - Exact format required: `#### Scenario: Name`
-- Debug with: `spectr show [change] --json --deltas-only`
+- Debug by reading the delta spec file directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
 
 ### Validation Tips
 
 ```bash
 # Always use strict mode for comprehensive checks
 spectr validate [change] --strict
-
-# Debug delta parsing
-spectr show [change] --json | jq '.deltas'
-
-# Check specific requirement
-spectr show [spec] --json -r 1
 ```
+
+**For AI agents debugging:**
+- Read delta specs directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
+- Check spec content by reading: `spectr/specs/<capability>/spec.md`
 
 ## Happy Path Script
 
@@ -449,10 +449,13 @@ Only add complexity with:
 ### CLI Essentials
 ```bash
 spectr list              # What's in progress?
-spectr show [item]       # View details
 spectr validate --strict # Is it correct?
 spectr archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
 ```
+
+**Reading Details (for AI agents):**
+- Read `spectr/specs/<capability>/spec.md` for spec details
+- Read `spectr/changes/<change-id>/proposal.md` for change details
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,15 +282,15 @@ After deployment, archive completed changes:
 **Before Creating Specs:**
 - Always check if capability already exists
 - Prefer modifying existing specs over creating duplicates
-- Use `spectr show [spec]` to review current state
+- Read `spectr/specs/<capability>/spec.md` directly to review current state
 - If request is ambiguous, ask 1–2 clarifying questions before scaffolding
 
 ### Search Guidance
 - Enumerate specs: `spectr spec list --long` (or `--json` for scripts)
 - Enumerate changes: `spectr list` (or `spectr change list --json` - deprecated but available)
-- Show details:
-  - Spec: `spectr show <spec-id> --type spec` (use `--json` for filters)
-  - Change: `spectr show <change-id> --json --deltas-only`
+- Read details directly:
+  - Spec: Read `spectr/specs/<capability>/spec.md`
+  - Change: Read `spectr/changes/<change-id>/proposal.md`
 - Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" spectr/specs`
 
 ## Quick Start
@@ -301,7 +301,6 @@ After deployment, archive completed changes:
 # Essential commands
 spectr list                  # List active changes
 spectr list --specs          # List specifications
-spectr show [item]           # Display change or spec
 spectr validate [item]       # Validate changes or specs
 spectr archive <change-id> [--yes|-y]   # Archive after deployment (add --yes for non-interactive runs)
 
@@ -310,13 +309,16 @@ spectr init [path]           # Initialize Spectr
 spectr update [path]         # Update instruction files
 
 # Interactive mode
-spectr show                  # Prompts for selection
 spectr validate              # Bulk validation mode
 
 # Debugging
-spectr show [change] --json --deltas-only
 spectr validate [change] --strict
 ```
+
+**Reading Specs and Changes (for AI agents):**
+- Specs: Read `spectr/specs/<capability>/spec.md` directly
+- Changes: Read `spectr/changes/<change-id>/proposal.md` directly
+- Tasks: Read `spectr/changes/<change-id>/tasks.md` directly
 
 ### Command Flags
 
@@ -507,20 +509,18 @@ Example for RENAMED:
 
 **Silent scenario parsing failures**
 - Exact format required: `#### Scenario: Name`
-- Debug with: `spectr show [change] --json --deltas-only`
+- Debug by reading the delta spec file directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
 
 ### Validation Tips
 
 ```bash
 # Always use strict mode for comprehensive checks
 spectr validate [change] --strict
-
-# Debug delta parsing
-spectr show [change] --json | jq '.deltas'
-
-# Check specific requirement
-spectr show [spec] --json -r 1
 ```
+
+**For AI agents debugging:**
+- Read delta specs directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
+- Check spec content by reading: `spectr/specs/<capability>/spec.md`
 
 ## Happy Path Script
 
@@ -655,10 +655,13 @@ Only add complexity with:
 ### CLI Essentials
 ```bash
 spectr list              # What's in progress?
-spectr show [item]       # View details
 spectr validate --strict # Is it correct?
 spectr archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
 ```
+
+**Reading Details (for AI agents):**
+- Read `spectr/specs/<capability>/spec.md` for spec details
+- Read `spectr/changes/<change-id>/proposal.md` for change details
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,15 +281,15 @@ After deployment, archive completed changes:
 **Before Creating Specs:**
 - Always check if capability already exists
 - Prefer modifying existing specs over creating duplicates
-- Use `spectr show [spec]` to review current state
+- Read `spectr/specs/<capability>/spec.md` directly to review current state
 - If request is ambiguous, ask 1–2 clarifying questions before scaffolding
 
 ### Search Guidance
 - Enumerate specs: `spectr spec list --long` (or `--json` for scripts)
 - Enumerate changes: `spectr list` (or `spectr change list --json` - deprecated but available)
-- Show details:
-  - Spec: `spectr show <spec-id> --type spec` (use `--json` for filters)
-  - Change: `spectr show <change-id> --json --deltas-only`
+- Read details directly:
+  - Spec: Read `spectr/specs/<capability>/spec.md`
+  - Change: Read `spectr/changes/<change-id>/proposal.md`
 - Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" spectr/specs`
 
 ## Quick Start
@@ -300,7 +300,6 @@ After deployment, archive completed changes:
 # Essential commands
 spectr list                  # List active changes
 spectr list --specs          # List specifications
-spectr show [item]           # Display change or spec
 spectr validate [item]       # Validate changes or specs
 spectr archive <change-id> [--yes|-y]   # Archive after deployment (add --yes for non-interactive runs)
 
@@ -309,13 +308,16 @@ spectr init [path]           # Initialize Spectr
 spectr update [path]         # Update instruction files
 
 # Interactive mode
-spectr show                  # Prompts for selection
 spectr validate              # Bulk validation mode
 
 # Debugging
-spectr show [change] --json --deltas-only
 spectr validate [change] --strict
 ```
+
+**Reading Specs and Changes (for AI agents):**
+- Specs: Read `spectr/specs/<capability>/spec.md` directly
+- Changes: Read `spectr/changes/<change-id>/proposal.md` directly
+- Tasks: Read `spectr/changes/<change-id>/tasks.md` directly
 
 ### Command Flags
 
@@ -506,20 +508,18 @@ Example for RENAMED:
 
 **Silent scenario parsing failures**
 - Exact format required: `#### Scenario: Name`
-- Debug with: `spectr show [change] --json --deltas-only`
+- Debug by reading the delta spec file directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
 
 ### Validation Tips
 
 ```bash
 # Always use strict mode for comprehensive checks
 spectr validate [change] --strict
-
-# Debug delta parsing
-spectr show [change] --json | jq '.deltas'
-
-# Check specific requirement
-spectr show [spec] --json -r 1
 ```
+
+**For AI agents debugging:**
+- Read delta specs directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
+- Check spec content by reading: `spectr/specs/<capability>/spec.md`
 
 ## Happy Path Script
 
@@ -654,10 +654,13 @@ Only add complexity with:
 ### CLI Essentials
 ```bash
 spectr list              # What's in progress?
-spectr show [item]       # View details
 spectr validate --strict # Is it correct?
 spectr archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
 ```
+
+**Reading Details (for AI agents):**
+- Read `spectr/specs/<capability>/spec.md` for spec details
+- Read `spectr/changes/<change-id>/proposal.md` for change details
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Active Changes:
   add-two-factor-auth    Add 2FA authentication support
   refactor-validation    Improve validation error messages
 
-Run 'spectr show <change>' for details
+Run 'spectr view <change>' for details
 ```
 
 ### spectr validate

--- a/docs/src/content/docs/guides/archiving-workflow.md
+++ b/docs/src/content/docs/guides/archiving-workflow.md
@@ -65,7 +65,7 @@ Before archiving, verify:
 
 ```bash
 # See what's in your change
-spectr show <change-id> --json
+spectr view <change-id> --json
 
 # Validate the change passes strict checks
 spectr validate <change-id> --strict
@@ -206,7 +206,7 @@ spectr/
 
 ```bash
 # View current spec requirements
-spectr show auth --json | jq '.requirements[].title'
+spectr view auth --json | jq '.requirements[].title'
 
 # Verify your modified requirement name matches
 ```

--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -27,29 +27,29 @@ spectr spec list --long
 - `--long` - Show detailed information
 - `--json` - Machine-readable JSON output
 
-### Show Details
+### View Details
 
 Display details about a specific change or spec:
 
 ```bash
-spectr show <change-id>
-spectr show <spec-id> --type spec
+spectr view <change-id>
+spectr view <spec-id> --type spec
 ```
 
 **Examples:**
 ```bash
-# Show change details
-spectr show add-two-factor-auth
+# View change details
+spectr view add-two-factor-auth
 
-# Show spec details
-spectr show auth --type spec
+# View spec details
+spectr view auth --type spec
 
 # JSON output with delta details
-spectr show add-two-factor-auth --json --deltas-only
+spectr view add-two-factor-auth --json --deltas-only
 ```
 
 **Options:**
-- `--type change|spec` - Specify what to show (required if ambiguous)
+- `--type change|spec` - Specify what to view (required if ambiguous)
 - `--json` - Machine-readable JSON output
 - `--deltas-only` - Show only spec deltas
 
@@ -152,7 +152,7 @@ Some commands support interactive mode:
 
 ```bash
 # Interactive spec selection
-spectr show
+spectr view
 
 # Interactive validation
 spectr validate
@@ -225,7 +225,7 @@ spectr validate add-feature --strict
 
 ```bash
 # 1. Check change details
-spectr show add-feature
+spectr view add-feature
 
 # 2. Implement according to tasks.md
 
@@ -250,11 +250,11 @@ spectr list
 # 2. List all specs
 spectr list --specs
 
-# 3. Show details of a change
-spectr show add-feature
+# 3. View details of a change
+spectr view add-feature
 
-# 4. Show details of a spec
-spectr show auth --type spec
+# 4. View details of a spec
+spectr view auth --type spec
 
 # 5. Validate everything
 spectr validate --strict
@@ -279,10 +279,10 @@ If you get "ambiguous item" error, specify the type:
 
 ```bash
 # Error: Could be change or spec
-spectr show auth
+spectr view auth
 
 # Solution: Specify type
-spectr show auth --type spec
+spectr view auth --type spec
 ```
 
 ### Permission denied
@@ -308,7 +308,7 @@ Use JSON output with `jq` for filtering:
 spectr list --json | jq '.changes[].id'
 
 # Get specific change details
-spectr show add-feature --json | jq '.proposal'
+spectr view add-feature --json | jq '.proposal'
 ```
 
 ### Quick Validation Loop

--- a/internal/init/templates/spectr/AGENTS.md.tmpl
+++ b/internal/init/templates/spectr/AGENTS.md.tmpl
@@ -85,15 +85,15 @@ After deployment, archive completed changes:
 **Before Creating Specs:**
 - Always check if capability already exists
 - Prefer modifying existing specs over creating duplicates
-- Use `spectr show [spec]` to review current state
+- Read `spectr/specs/<capability>/spec.md` directly to review current state
 - If request is ambiguous, ask 1–2 clarifying questions before scaffolding
 
 ### Search Guidance
 - Enumerate specs: `spectr spec list --long` (or `--json` for scripts)
 - Enumerate changes: `spectr list` (or `spectr change list --json` - deprecated but available)
-- Show details:
-  - Spec: `spectr show <spec-id> --type spec` (use `--json` for filters)
-  - Change: `spectr show <change-id> --json --deltas-only`
+- Read details directly:
+  - Spec: Read `spectr/specs/<capability>/spec.md`
+  - Change: Read `spectr/changes/<change-id>/proposal.md`
 - Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" spectr/specs`
 
 ## Quick Start
@@ -104,7 +104,6 @@ After deployment, archive completed changes:
 # Essential commands
 spectr list                  # List active changes
 spectr list --specs          # List specifications
-spectr show [item]           # Display change or spec
 spectr validate [item]       # Validate changes or specs
 spectr archive <change-id> [--yes|-y]   # Archive after deployment (add --yes for non-interactive runs)
 
@@ -113,13 +112,16 @@ spectr init [path]           # Initialize Spectr
 spectr update [path]         # Update instruction files
 
 # Interactive mode
-spectr show                  # Prompts for selection
 spectr validate              # Bulk validation mode
 
 # Debugging
-spectr show [change] --json --deltas-only
 spectr validate [change] --strict
 ```
+
+**Reading Specs and Changes (for AI agents):**
+- Specs: Read `spectr/specs/<capability>/spec.md` directly
+- Changes: Read `spectr/changes/<change-id>/proposal.md` directly
+- Tasks: Read `spectr/changes/<change-id>/tasks.md` directly
 
 ### Command Flags
 
@@ -310,20 +312,18 @@ Example for RENAMED:
 
 **Silent scenario parsing failures**
 - Exact format required: `#### Scenario: Name`
-- Debug with: `spectr show [change] --json --deltas-only`
+- Debug by reading the delta spec file directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
 
 ### Validation Tips
 
 ```bash
 # Always use strict mode for comprehensive checks
 spectr validate [change] --strict
-
-# Debug delta parsing
-spectr show [change] --json | jq '.deltas'
-
-# Check specific requirement
-spectr show [spec] --json -r 1
 ```
+
+**For AI agents debugging:**
+- Read delta specs directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
+- Check spec content by reading: `spectr/specs/<capability>/spec.md`
 
 ## Happy Path Script
 
@@ -458,9 +458,12 @@ Only add complexity with:
 ### CLI Essentials
 ```bash
 spectr list              # What's in progress?
-spectr show [item]       # View details
 spectr validate --strict # Is it correct?
 spectr archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
 ```
+
+**Reading Details (for AI agents):**
+- Read `spectr/specs/<capability>/spec.md` for spec details
+- Read `spectr/changes/<change-id>/proposal.md` for change details
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.

--- a/internal/init/templates/tools/slash-apply.md.tmpl
+++ b/internal/init/templates/tools/slash-apply.md.tmpl
@@ -9,7 +9,8 @@ Track these steps as TODOs and complete them one by one.
 2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
 3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
 4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
-5. Reference `spectr list` or `spectr show <item>` when additional context is required.
+5. Reference `spectr list` when additional context is required.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+- Read `spectr/changes/<id>/proposal.md` for proposal details.
+- Read `spectr/changes/<id>/specs/<capability>/spec.md` for delta specs.

--- a/internal/init/templates/tools/slash-proposal.md.tmpl
+++ b/internal/init/templates/tools/slash-proposal.md.tmpl
@@ -14,6 +14,7 @@
 7. Validate with `spectr validate <id> --strict` and resolve every issue before sharing the proposal.
 
 **Reference**
-- Use `spectr show <id> --json --deltas-only` or `spectr show <spec> --type spec` to inspect details when validation fails.
+- Read delta specs directly at `spectr/changes/<id>/specs/<capability>/spec.md` when validation fails.
+- Read existing specs at `spectr/specs/<capability>/spec.md` to understand current state.
 - Search existing requirements with `rg -n "Requirement:|Scenario:" spectr/specs` before writing new ones.
 - Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.

--- a/internal/init/templates/tools/slash-sync.md.tmpl
+++ b/internal/init/templates/tools/slash-sync.md.tmpl
@@ -31,6 +31,6 @@
    - Show summary of changes made.
 
 ### Reference
-- Use `spectr show <spec> --type spec` to view current spec content.
+- Read `spectr/specs/<capability>/spec.md` to view current spec content.
 - Search code with `rg` to find implementations.
 - Validate after edits with `spectr validate --strict`.

--- a/spectr/AGENTS.md
+++ b/spectr/AGENTS.md
@@ -78,15 +78,15 @@ When code implementation diverges from specs, sync to update specs:
 **Before Creating Specs:**
 - Always check if capability already exists
 - Prefer modifying existing specs over creating duplicates
-- Use `spectr show [spec]` to review current state
+- Read `spectr/specs/<capability>/spec.md` directly to review current state
 - If request is ambiguous, ask 1–2 clarifying questions before scaffolding
 
 ### Search Guidance
 - Enumerate specs: `spectr spec list --long` (or `--json` for scripts)
 - Enumerate changes: `spectr list` (or `spectr change list --json` - deprecated but available)
-- Show details:
-  - Spec: `spectr show <spec-id> --type spec` (use `--json` for filters)
-  - Change: `spectr show <change-id> --json --deltas-only`
+- Read details directly:
+  - Spec: Read `spectr/specs/<capability>/spec.md`
+  - Change: Read `spectr/changes/<change-id>/proposal.md`
 - Full-text search (use ripgrep): `rg -n "Requirement:|Scenario:" spectr/specs`
 
 ## Quick Start
@@ -97,7 +97,6 @@ When code implementation diverges from specs, sync to update specs:
 # Essential commands
 spectr list                  # List active changes
 spectr list --specs          # List specifications
-spectr show [item]           # Display change or spec
 spectr validate [item]       # Validate changes or specs
 
 # Project management
@@ -105,13 +104,16 @@ spectr init [path]           # Initialize Spectr
 spectr update [path]         # Update instruction files
 
 # Interactive mode
-spectr show                  # Prompts for selection
 spectr validate              # Bulk validation mode
 
 # Debugging
-spectr show [change] --json --deltas-only
 spectr validate [change] --strict
 ```
+
+**Reading Specs and Changes (for AI agents):**
+- Specs: Read `spectr/specs/<capability>/spec.md` directly
+- Changes: Read `spectr/changes/<change-id>/proposal.md` directly
+- Tasks: Read `spectr/changes/<change-id>/tasks.md` directly
 
 ### Command Flags
 
@@ -299,20 +301,18 @@ Example for RENAMED:
 
 **Silent scenario parsing failures**
 - Exact format required: `#### Scenario: Name`
-- Debug with: `spectr show [change] --json --deltas-only`
+- Debug by reading the delta spec file directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
 
 ### Validation Tips
 
 ```bash
 # Always use strict mode for comprehensive checks
 spectr validate [change] --strict
-
-# Debug delta parsing
-spectr show [change] --json | jq '.deltas'
-
-# Check specific requirement
-spectr show [spec] --json -r 1
 ```
+
+**For AI agents debugging:**
+- Read delta specs directly: `spectr/changes/<change-id>/specs/<capability>/spec.md`
+- Check spec content by reading: `spectr/specs/<capability>/spec.md`
 
 ## Happy Path Script
 
@@ -445,8 +445,11 @@ Only add complexity with:
 ### CLI Essentials
 ```bash
 spectr list              # What's in progress?
-spectr show [item]       # View details
 spectr validate --strict # Is it correct?
 ```
+
+**Reading Details (for AI agents):**
+- Read `spectr/specs/<capability>/spec.md` for spec details
+- Read `spectr/changes/<change-id>/proposal.md` for change details
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.

--- a/spectr/changes/remove-spectr-show-references/proposal.md
+++ b/spectr/changes/remove-spectr-show-references/proposal.md
@@ -1,0 +1,35 @@
+# Change: Remove incorrect `spectr show` references from documentation
+
+## Why
+
+The documentation across multiple files references a `spectr show` command that does **not exist**. The CLI only has these commands: `init`, `list`, `validate`, `archive`, `view`, `version`. Users attempting to use `spectr show` receive an error: "unexpected argument show". This misleads users and AI assistants who rely on the documentation.
+
+Additionally, AI agent documentation incorrectly suggests using CLI commands to read specs/changes. **AI agents should read files directly** using their native file reading capabilities (e.g., `Read` tool, `cat`), not CLI commands like `spectr view`. The `spectr view` command is for human users only.
+
+## What Changes
+
+- **BREAKING**: Remove all references to `spectr show` command from documentation
+- Remove `spectr show [item]`, `spectr show <id>`, `spectr show <spec>`, and related examples
+- **For user documentation**: Reference `spectr view` as the correct command for viewing specs/changes
+- **For AI agent documentation**: Replace CLI viewing commands with direct file reading instructions
+  - Specs: Read `spectr/specs/<capability>/spec.md` directly
+  - Changes: Read `spectr/changes/<change-id>/proposal.md` directly
+- Update troubleshooting sections to remove `spectr show` debug suggestions
+- Update Quick Reference sections appropriately for the audience (users vs AI agents)
+
+## Impact
+
+- Affected specs: `documentation`
+- Affected files:
+  - `CLAUDE.md` (root)
+  - `AGENTS.md` (root)
+  - `spectr/AGENTS.md`
+  - `.github/copilot-instructions.md`
+  - `.claude/commands/spectr/*.md`
+  - `.gemini/commands/spectr/*.toml`
+  - `.agent/workflows/*.md`
+  - `internal/init/templates/spectr/AGENTS.md.tmpl`
+  - `internal/init/templates/tools/*.md.tmpl`
+  - `docs/src/content/docs/reference/cli-commands.md`
+  - `docs/src/content/docs/guides/archiving-workflow.md`
+  - `README.md`

--- a/spectr/changes/remove-spectr-show-references/specs/documentation/spec.md
+++ b/spectr/changes/remove-spectr-show-references/specs/documentation/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Complete Command Reference
+The system SHALL document all CLI commands with flags, examples, and expected output. Documentation SHALL only reference commands that actually exist in the CLI. Documentation SHALL distinguish between instructions for human users and AI agents.
+
+#### Scenario: User learns init command usage
+- **WHEN** a user reads the init command documentation
+- **THEN** they SHALL see all available flags (`--path`, `--tools`, `--non-interactive`) with explanations and examples
+
+#### Scenario: User learns list command options
+- **WHEN** a user reads the list command documentation
+- **THEN** they SHALL understand the `--specs`, `--json`, and `--long` flags with example outputs
+
+#### Scenario: User learns validate command options
+- **WHEN** a user reads the validate command documentation
+- **THEN** they SHALL see how to use `--strict` flag and understand what validation rules are enforced
+
+#### Scenario: User learns archive command
+- **WHEN** a user reads the archive command documentation
+- **THEN** they SHALL understand the archiving workflow and `--skip-specs` flag usage
+
+#### Scenario: User learns view command options
+- **WHEN** a user reads the view command documentation
+- **THEN** they SHALL understand the `--json` flag for dashboard output
+
+#### Scenario: Documentation accuracy
+- **WHEN** a user or AI assistant reads any documentation file
+- **THEN** all referenced CLI commands SHALL exist and work as documented
+- **AND** no nonexistent commands (such as `spectr show`) SHALL be referenced
+
+#### Scenario: AI agent documentation uses direct file reading
+- **WHEN** an AI agent reads documentation for viewing specs or changes
+- **THEN** the documentation SHALL instruct agents to read files directly (e.g., `spectr/specs/<capability>/spec.md` or `spectr/changes/<change-id>/proposal.md`)
+- **AND** the documentation SHALL NOT instruct agents to use CLI commands like `spectr view` for reading content
+- **AND** the `spectr view` command SHALL only be documented for human users

--- a/spectr/changes/remove-spectr-show-references/tasks.md
+++ b/spectr/changes/remove-spectr-show-references/tasks.md
@@ -1,0 +1,41 @@
+## 1. Core AI Agent Documentation Files
+
+These files contain instructions for AI agents. Replace `spectr show` with direct file reading instructions (NOT `spectr view`).
+
+- [x] 1.1 Update `CLAUDE.md` - replace `spectr show` with direct file reading (`spectr/specs/<cap>/spec.md`, `spectr/changes/<id>/proposal.md`)
+- [x] 1.2 Update `AGENTS.md` - replace `spectr show` with direct file reading
+- [x] 1.3 Update `spectr/AGENTS.md` - replace `spectr show` with direct file reading
+- [x] 1.4 Update `.github/copilot-instructions.md` - replace `spectr show` with direct file reading
+
+## 2. AI Tool Command Files
+
+These files are slash commands for AI agents. Replace `spectr show` with direct file reading instructions.
+
+- [x] 2.1 Update `.claude/commands/spectr/proposal.md` - replace `spectr show` with direct file reading
+- [x] 2.2 Update `.claude/commands/spectr/apply.md` - replace `spectr show` with direct file reading
+- [x] 2.3 Update `.claude/commands/spectr/sync.md` - replace `spectr show` with direct file reading
+- [x] 2.4 Update `.gemini/commands/spectr/*.toml` - replace `spectr show` with direct file reading
+- [x] 2.5 Update `.agent/workflows/*.md` - replace `spectr show` with direct file reading (if exists)
+- [x] 2.6 Update `.gemini/commands/spectr-*.toml` - replace `spectr show` with direct file reading
+
+## 3. Template Files
+
+These are templates for `spectr init`. Replace `spectr show` with direct file reading instructions.
+
+- [x] 3.1 Update `internal/init/templates/spectr/AGENTS.md.tmpl` - replace `spectr show` with direct file reading
+- [x] 3.2 Update `internal/init/templates/tools/slash-apply.md.tmpl` - replace `spectr show` with direct file reading
+- [x] 3.3 Update `internal/init/templates/tools/slash-proposal.md.tmpl` - replace `spectr show` with direct file reading
+- [x] 3.4 Update `internal/init/templates/tools/slash-sync.md.tmpl` - replace `spectr show` with direct file reading
+
+## 4. Public User Documentation
+
+These files are for human users. Replace `spectr show` with `spectr view` (the correct command for users).
+
+- [x] 4.1 Update `docs/src/content/docs/reference/cli-commands.md` - replace `spectr show` with `spectr view`
+- [x] 4.2 Update `docs/src/content/docs/guides/archiving-workflow.md` - replace `spectr show` with `spectr view`
+- [x] 4.3 Update `README.md` - replace `spectr show` with `spectr view` (if any references exist)
+
+## 5. Validation
+
+- [x] 5.1 Run `spectr validate remove-spectr-show-references --strict` to ensure change is valid
+- [x] 5.2 Run `rg "spectr show" --type md --type go` to verify no remaining references (except archive/ history)


### PR DESCRIPTION
## Summary

Remove all references to the non-existent `spectr show` command from documentation across the entire codebase. The CLI does not have a `show` command, which was causing user confusion and errors.

### Changes Made

**For AI Agent Documentation:**
- Replace `spectr show` references with direct file reading instructions
- AI agents should read `spectr/specs/<capability>/spec.md` and `spectr/changes/<change-id>/proposal.md` directly

**For User Documentation:**
- Replace `spectr show` references with the correct `spectr view` command

### Files Updated
- Core AI docs: `CLAUDE.md`, `AGENTS.md`, `spectr/AGENTS.md`, `.github/copilot-instructions.md`
- AI tool commands: `.claude/commands/spectr/*.md`, `.gemini/commands/spectr/*.toml`, `.agent/workflows/*.md`
- Templates: `internal/init/templates/spectr/AGENTS.md.tmpl`, `internal/init/templates/tools/*.md.tmpl`
- User docs: `docs/src/content/docs/reference/cli-commands.md`, `docs/src/content/docs/guides/archiving-workflow.md`, `README.md`

### Spec Changes
Modified the "Complete Command Reference" requirement in the documentation capability to ensure all referenced CLI commands actually exist and work as documented.

This change improves documentation accuracy and prevents user confusion from referencing non-existent commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command references from "spectr show" to "spectr view" across documentation and guides
  * Enhanced guidance with direct file-path instructions for accessing specifications and changes
  * Improved documentation for AI agent workflows with clearer references to specification files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->