### PR TITLE
feat: add help toggle hotkey (?) to TUI interactive modes

### DIFF
--- a/internal/tui/table_test.go
+++ b/internal/tui/table_test.go
@@ -213,12 +213,22 @@ func TestTablePicker_View(t *testing.T) {
 	picker := NewTablePicker(config)
 	view := picker.View()
 
-	// View should contain table and help
+	// View should contain table and minimal footer (showHelp=false by default)
 	if !strings.Contains(view, "ID") {
 		t.Error("View should contain column header")
 	}
-	if !strings.Contains(view, "navigate") {
-		t.Error("View should contain help text")
+	if !strings.Contains(view, "?: help") {
+		t.Error("View should contain minimal footer with help hint")
+	}
+	if strings.Contains(view, "navigate") {
+		t.Error("View should not contain full help by default")
+	}
+
+	// When showHelp is toggled, should show full help
+	picker.showHelp = true
+	viewWithHelp := picker.View()
+	if !strings.Contains(viewWithHelp, "navigate") {
+		t.Error("View should contain full help when showHelp is true")
 	}
 }
 

--- a/spectr/changes/add-help-hotkey/tasks.md
+++ b/spectr/changes/add-help-hotkey/tasks.md
@@ -1,31 +1,31 @@
 ## 1. Core Implementation
 
-- [ ] 1.1 Add `showHelp` boolean field to `TablePicker` struct in `internal/tui/table.go`
-- [ ] 1.2 Add `?` key handler in `TablePicker.Update()` to toggle `showHelp` state
-- [ ] 1.3 Create `generateMinimalFooter()` method that shows only item count, project path, and `?: help` hint
-- [ ] 1.4 Modify `generateHelpText()` to be the full help text (existing implementation)
-- [ ] 1.5 Update `View()` to show minimal footer by default, full help when `showHelp` is true
-- [ ] 1.6 Auto-hide help on navigation keys (↑/↓/j/k) to return to minimal view
+- [x] 1.1 Add `showHelp` boolean field to `TablePicker` struct in `internal/tui/table.go`
+- [x] 1.2 Add `?` key handler in `TablePicker.Update()` to toggle `showHelp` state
+- [x] 1.3 Create `generateMinimalFooter()` method that shows only item count, project path, and `?: help` hint
+- [x] 1.4 Modify `generateHelpText()` to be the full help text (existing implementation)
+- [x] 1.5 Update `View()` to show minimal footer by default, full help when `showHelp` is true
+- [x] 1.6 Auto-hide help on navigation keys (↑/↓/j/k) to return to minimal view
 
 ## 2. Interactive Model Updates
 
-- [ ] 2.1 Add `showHelp` field to `interactiveModel` in `internal/list/interactive.go`
-- [ ] 2.2 Add `?` key handler in `interactiveModel.Update()` to toggle help display
-- [ ] 2.3 Update `View()` to conditionally show minimal or full help text
-- [ ] 2.4 Update `rebuildUnifiedTable()` to preserve help toggle state
-- [ ] 2.5 Auto-hide help on navigation keys to avoid cluttering view
+- [x] 2.1 Add `showHelp` field to `interactiveModel` in `internal/list/interactive.go`
+- [x] 2.2 Add `?` key handler in `interactiveModel.Update()` to toggle help display
+- [x] 2.3 Update `View()` to conditionally show minimal or full help text
+- [x] 2.4 Update `rebuildUnifiedTable()` to preserve help toggle state
+- [x] 2.5 Auto-hide help on navigation keys to avoid cluttering view
 
 ## 3. Testing
 
-- [ ] 3.1 Add test for `?` key toggling help visibility in TablePicker
-- [ ] 3.2 Add test for minimal footer content (item count, project path, `?: help`)
-- [ ] 3.3 Add test for full help content when help is shown
-- [ ] 3.4 Add test for auto-hide on navigation keys
-- [ ] 3.5 Add test for help toggle in interactiveModel
+- [x] 3.1 Add test for `?` key toggling help visibility in TablePicker
+- [x] 3.2 Add test for minimal footer content (item count, project path, `?: help`)
+- [x] 3.3 Add test for full help content when help is shown
+- [x] 3.4 Add test for auto-hide on navigation keys
+- [x] 3.5 Add test for help toggle in interactiveModel
 
 ## 4. Validation
 
-- [ ] 4.1 Run `go test ./...` to verify all tests pass
+- [x] 4.1 Run `go test ./...` to verify all tests pass
 - [ ] 4.2 Manual test: verify `spectr list -I` shows minimal footer
 - [ ] 4.3 Manual test: verify pressing `?` reveals full hotkey list
 - [ ] 4.4 Manual test: verify pressing `?` again or navigating hides help


### PR DESCRIPTION
## Summary
- Hide hotkey hints by default to reduce visual clutter in TUI interactive modes
- Add `?` hotkey to toggle display of full hotkey reference
- Show minimal footer by default: `showing: X | project: /path | ?: help`
- Auto-hide help when navigating with arrow keys or j/k

## Changes
- **internal/tui/table.go**: Add `showHelp` field, `generateMinimalFooter()`, and `?` key handler to `TablePicker`
- **internal/list/interactive.go**: Add `showHelp` and `minimalFooter` fields to `interactiveModel`, update all `RunInteractive*` functions
- **internal/tui/table_test.go**: Add tests for help toggle in TablePicker
- **internal/list/interactive_test.go**: Add 6 new tests for help toggle functionality

## Test plan
- [x] `go test ./...` passes
- [x] `nix develop -c lint` passes (0 issues)
- [ ] Manual test: `spectr list -I` shows minimal footer
- [ ] Manual test: pressing `?` reveals full hotkey list
- [ ] Manual test: pressing `?` again or navigating hides help

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive help toggle: press "?" to show/hide detailed help text.
  * Implemented minimal footer display when help is hidden, showing item count, project information, and help hint.
  * Help automatically hides during navigation (arrow keys or j/k shortcuts).

* **Tests**
  * Added comprehensive test coverage for help toggle functionality, navigation behavior, and minimal footer display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->