### PR TITLE
feat: show configured provider status in init wizard

### DIFF
--- a/spectr/changes/add-configured-provider-detection/proposal.md
+++ b/spectr/changes/add-configured-provider-detection/proposal.md
@@ -1,0 +1,24 @@
+# Change: Show Already-Configured Providers in Init Wizard TUI
+
+## Why
+
+When running `spectr init` on a project that already has some providers configured, users have no visual indication of which tools are already set up. This forces users to either:
+1. Manually check file existence before running init
+2. Accidentally re-select already-configured providers (harmless but confusing)
+3. Miss the opportunity to understand their current configuration state
+
+The `IsConfigured()` method exists on all providers but isn't used in the wizard TUI.
+
+## What Changes
+
+- **Detect configured providers**: Call `IsConfigured(projectPath)` on each provider during wizard initialization
+- **Visual indicator**: Show a distinct marker (e.g., `[✓ configured]` or different color) for already-configured providers
+- **Pre-selection behavior**: Already-configured providers are pre-selected by default, allowing users to keep or deselect them
+- **Legend/help text**: Add explanation of the configured indicator in the selection screen
+
+## Impact
+
+- Affected specs: `cli-interface` (adds requirement for configured provider display)
+- Affected code:
+  - `internal/init/wizard.go` - WizardModel initialization and rendering
+  - `internal/init/wizard.go` - `renderProviderGroup()` and `renderSelect()` functions

--- a/spectr/changes/add-configured-provider-detection/specs/cli-interface/spec.md
+++ b/spectr/changes/add-configured-provider-detection/specs/cli-interface/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Configured Provider Detection in Init Wizard
+
+The initialization wizard SHALL detect which AI tool providers are already configured for the project and display this status in the tool selection screen. Already-configured providers SHALL be visually distinguished and pre-selected by default.
+
+#### Scenario: Display configured indicator for already-configured providers
+
+- **WHEN** user runs `spectr init` on a project with `CLAUDE.md` already present
+- **AND** user reaches the tool selection screen
+- **THEN** the Claude Code entry displays a "configured" indicator (e.g., dimmed text or badge)
+- **AND** the indicator is visually distinct from the selection checkbox
+- **AND** other unconfigured providers do NOT show the configured indicator
+
+#### Scenario: Pre-select already-configured providers
+
+- **WHEN** user runs `spectr init` on a project with some providers already configured
+- **AND** user reaches the tool selection screen
+- **THEN** already-configured providers have their checkboxes pre-selected
+- **AND** users can deselect them if they don't want to update the configuration
+- **AND** unconfigured providers remain unselected by default
+
+#### Scenario: Help text explains configured indicator
+
+- **WHEN** user is on the tool selection screen
+- **THEN** the help text or screen description explains what the "configured" indicator means
+- **AND** the explanation clarifies that selecting a configured provider will update its files
+
+#### Scenario: No configured providers
+
+- **WHEN** user runs `spectr init` on a fresh project with no providers configured
+- **AND** user reaches the tool selection screen
+- **THEN** no providers show the configured indicator
+- **AND** no providers are pre-selected
+- **AND** the screen functions as before this change
+
+#### Scenario: All providers configured
+
+- **WHEN** user runs `spectr init` on a project with all available providers configured
+- **AND** user reaches the tool selection screen
+- **THEN** all providers show the configured indicator
+- **AND** all providers are pre-selected
+- **AND** user can deselect providers they don't want to update
+
+#### Scenario: Configured detection uses provider's IsConfigured method
+
+- **WHEN** the wizard initializes
+- **THEN** it calls `IsConfigured(projectPath)` on each provider
+- **AND** the result is cached for the wizard session (not re-checked on each render)
+- **AND** providers with global paths (like Codex) are correctly detected

--- a/spectr/changes/add-configured-provider-detection/tasks.md
+++ b/spectr/changes/add-configured-provider-detection/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+
+- [x] 1.1 Add `configuredProviders` map to `WizardModel` struct in `internal/init/wizard.go`
+- [x] 1.2 Update `NewWizardModel()` to call `IsConfigured()` on each provider and populate the map
+- [x] 1.3 Update `NewWizardModel()` to pre-select already-configured providers in `selectedProviders` map
+- [x] 1.4 Update `renderProviderGroup()` to display a "configured" indicator for already-configured providers
+- [x] 1.5 Update `renderSelect()` help text to explain the configured indicator
+
+## 2. Testing
+
+- [x] 2.1 Add test case for `NewWizardModel` with configured providers
+- [x] 2.2 Add test case for `NewWizardModel` with no configured providers
+- [x] 2.3 Verify visual rendering shows configured indicator correctly
+
+## 3. Validation
+
+- [x] 3.1 Run `spectr validate add-configured-provider-detection --strict`
+- [ ] 3.2 Manual testing with fresh project (no configured providers)
+- [ ] 3.3 Manual testing with project that has some providers configured


### PR DESCRIPTION
## Summary

- Add detection of already-configured providers when running `spectr init`
- Display "(configured)" indicator next to providers that are already set up
- Pre-select configured providers by default so users can easily update their configs
- Add help text explaining what the "(configured)" indicator means

## Changes

- `internal/init/wizard.go`: Added `configuredProviders` map, detection logic in `NewWizardModel()`, visual indicator in `renderProviderGroup()`, and help text in `renderSelect()`
- `internal/init/wizard_test.go`: Added tests for configured provider detection, pre-selection, and rendering

## Test plan

- [x] Unit tests pass (`go test ./internal/init/...`)
- [x] Lint passes (`nix develop -c lint`)
- [x] Spectr validation passes (`spectr validate add-configured-provider-detection --strict`)
- [ ] Manual testing with fresh project (no configured providers)
- [ ] Manual testing with project that has some providers configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Init wizard now displays a "(configured)" indicator next to already-configured AI providers
  * Configured providers are automatically pre-selected in the setup wizard

* **Documentation**
  * Added specifications for configured provider detection in the init wizard

* **Tests**
  * Added tests for provider detection and UI rendering

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->