### PR TITLE
feat(validation): improve bulk validation output formatting

### DIFF
--- a/internal/validation/formatters.go
+++ b/internal/validation/formatters.go
@@ -7,7 +7,68 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-isatty"
 )
+
+// Color constants for validation output styling
+const (
+	ColorError   = "1" // Red
+	ColorWarning = "3" // Yellow
+)
+
+var (
+	// errorStyle styles [ERROR] labels in red
+	errorStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorError)).Bold(true)
+	// warningStyle styles [WARNING] labels in yellow
+	warningStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(ColorWarning)).Bold(true)
+)
+
+// isTTY returns true if stdout is a terminal
+func isTTY() bool {
+	return isatty.IsTerminal(os.Stdout.Fd())
+}
+
+// formatLevel formats a validation level with color styling if in a TTY
+func formatLevel(level ValidationLevel) string {
+	label := fmt.Sprintf("[%s]", level)
+	if !isTTY() {
+		return label
+	}
+	switch level {
+	case LevelError:
+		return errorStyle.Render(label)
+	case LevelWarning:
+		return warningStyle.Render(label)
+	case LevelInfo:
+		return label
+	}
+
+	return label
+}
+
+// ToRelativePath converts an absolute path to a path relative to the
+// spectr/ directory. It removes everything up to and including the
+// spectr/ prefix.
+// Example: /home/user/project/spectr/changes/foo/spec.md -> changes/foo/spec.md
+func ToRelativePath(absPath string) string {
+	// Clean the path first
+	cleanPath := filepath.Clean(absPath)
+
+	// Look for spectr/ in the path
+	const spectrDir = "spectr" + string(filepath.Separator)
+	if idx := strings.Index(cleanPath, spectrDir); idx >= 0 {
+		return cleanPath[idx+len(spectrDir):]
+	}
+
+	// If no spectr/ found, just return the base name
+	return filepath.Base(cleanPath)
+}
 
 // BulkResult represents the result of validating a single item
 type BulkResult struct {
@@ -67,15 +128,27 @@ func PrintBulkJSONResults(results []BulkResult) {
 }
 
 // PrintBulkHumanResults prints bulk validation results in human format
+// with improved formatting: visual separation between failed items,
+// relative paths, issues grouped by file, colored error/warning labels,
+// enhanced summary, and type indicators.
 func PrintBulkHumanResults(results []BulkResult) {
 	passCount := 0
 	failCount := 0
+	errorCount := 0
+	warningCount := 0
+	isFirstFailed := true
 
 	for _, result := range results {
 		if result.Valid {
 			fmt.Printf("✓ %s (%s)\n", result.Name, result.Type)
 			passCount++
 		} else {
+			// Add blank line before each failed item (except the first)
+			if !isFirstFailed {
+				fmt.Println()
+			}
+			isFirstFailed = false
+
 			if result.Error != "" {
 				fmt.Printf(
 					"✗ %s (%s): %s\n",
@@ -83,6 +156,7 @@ func PrintBulkHumanResults(results []BulkResult) {
 					result.Type,
 					result.Error,
 				)
+				errorCount++
 			} else {
 				issueCount := len(result.Report.Issues)
 				fmt.Printf(
@@ -91,23 +165,101 @@ func PrintBulkHumanResults(results []BulkResult) {
 					result.Type,
 					issueCount,
 				)
-				for _, issue := range result.Report.Issues {
-					fmt.Printf(
-						"  [%s] %s: %s\n",
-						issue.Level,
-						issue.Path,
-						issue.Message,
-					)
-				}
+				// Count and print issues grouped by file
+				printGroupedIssues(
+					result.Report.Issues, &errorCount, &warningCount,
+				)
 			}
 			failCount++
 		}
 	}
 
-	fmt.Printf(
-		"\n%d passed, %d failed, %d total\n",
-		passCount,
-		failCount,
-		len(results),
-	)
+	// Print enhanced summary
+	printSummary(summaryParams{
+		passCount:    passCount,
+		failCount:    failCount,
+		errorCount:   errorCount,
+		warningCount: warningCount,
+		total:        len(results),
+	})
+}
+
+// printGroupedIssues prints issues grouped by their file path with indentation
+func printGroupedIssues(
+	issues []ValidationIssue, errorCount, warningCount *int,
+) {
+	// Group issues by file path
+	grouped := make(map[string][]ValidationIssue)
+	var order []string // Preserve order of first occurrence
+
+	for _, issue := range issues {
+		relPath := ToRelativePath(issue.Path)
+		if _, exists := grouped[relPath]; !exists {
+			order = append(order, relPath)
+		}
+		grouped[relPath] = append(grouped[relPath], issue)
+
+		// Count errors and warnings
+		switch issue.Level {
+		case LevelError:
+			*errorCount++
+		case LevelWarning:
+			*warningCount++
+		case LevelInfo:
+			// Info level issues are not counted in error/warning totals
+		}
+	}
+
+	// Print issues grouped by file
+	for _, path := range order {
+		fileIssues := grouped[path]
+		if len(fileIssues) == 1 {
+			// Single issue: print on one line
+			issue := fileIssues[0]
+			fmt.Printf("  %s %s: %s\n",
+				formatLevel(issue.Level),
+				path,
+				issue.Message,
+			)
+		} else {
+			// Multiple issues: print file header then indented issues
+			fmt.Printf("  %s:\n", path)
+			for _, issue := range fileIssues {
+				fmt.Printf("    %s %s\n",
+					formatLevel(issue.Level),
+					issue.Message,
+				)
+			}
+		}
+	}
+}
+
+// summaryParams holds parameters for printing the validation summary
+type summaryParams struct {
+	passCount    int
+	failCount    int
+	errorCount   int
+	warningCount int
+	total        int
+}
+
+// printSummary prints the validation summary line
+func printSummary(p summaryParams) {
+	if p.failCount > 0 {
+		fmt.Printf(
+			"\n%d passed, %d failed (%d errors, %d warnings), %d total\n",
+			p.passCount,
+			p.failCount,
+			p.errorCount,
+			p.warningCount,
+			p.total,
+		)
+	} else {
+		fmt.Printf(
+			"\n%d passed, %d failed, %d total\n",
+			p.passCount,
+			p.failCount,
+			p.total,
+		)
+	}
 }


### PR DESCRIPTION
## Summary
- Add lipgloss styling for colored `[ERROR]`/`[WARNING]` labels when running in a TTY
- Convert absolute paths to spectr-relative paths for cleaner, more readable output
- Add blank line spacing between failed items for visual separation
- Group issues by file path with indentation when multiple issues exist in the same file
- Enhance summary to show error/warning breakdown when failures exist (e.g., "2 passed, 1 failed (3 errors, 1 warning), 3 total")
- Add comprehensive unit tests for all new formatting features

## Test plan
- [x] Run `go test ./internal/validation/...` - all tests pass
- [x] Run `spectr validate improve-validate-output --strict` - validates successfully
- [x] Run `golangci-lint run ./internal/validation/...` - no issues
- [x] Verify colored output renders in TTY terminal
- [x] Verify plain text output when not in TTY

Implements the `improve-validate-output` change proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added colorized validation level labels for improved terminal readability.
  * Enhanced validation results display with issues grouped by file path and improved spacing.
  * Improved summary reporting showing detailed pass/fail counts and error/warning breakdown.

* **Style**
  * Updated validation level indicators to uppercase format for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->