### PR TITLE
refactor(archive): clean up code style and fix variable shadowing

### DIFF
--- a/WHY_SYNC.md
+++ b/WHY_SYNC.md
@@ -12,7 +12,7 @@ However, many developers work "Code First":
 1. Modify Code
 2. Update Spec to reflect Code
 
-The `/sync` command acknowledges that **Code is the ultimate Source of Truth**. It allows the agent to look at the current state of the codebase and "sync" the specs to match, regardless of whether a formal "Change" object was used. This bridges the gap for users who may not want to strictly follow the formal SDD lifecycle for every modification.
+The `/sync` command acknowledges that **Code can be understood as ultimate Source of Truth**. It allows the agent to look at the current state of the codebase and "sync" the specs to match, regardless of whether a formal "Change" object was used. This bridges the gap for users who may not want to strictly follow the formal SDD lifecycle for every modification.
 
 ## 2. `archive` is a Simple CLI Wrapper
 The old `/archive` slash command essentially just ran `spectr archive <id>`. This is a trivial operation that doesn't require a complex prompt. A user can simply ask the agent "archive change 123" or run the CLI command themselves.

--- a/internal/archive/archiver.go
+++ b/internal/archive/archiver.go
@@ -69,8 +69,9 @@ func Archive(cmd *ArchiveCmd, workingDir string) error {
 		changeID = selectedID
 		cmd.ChangeID = changeID
 	} else {
+		var result discovery.ResolveResult
 		// Resolve partial ID to full change ID
-		result, err := discovery.ResolveChangeID(changeID, projectRoot)
+		result, err = discovery.ResolveChangeID(changeID, projectRoot)
 		if err != nil {
 			return err
 		}
@@ -257,7 +258,8 @@ func updateSpecsWithTracking(
 		return OperationCounts{}, nil, err
 	}
 
-	if err := writeSpecs(mergedSpecs, workingDir); err != nil {
+	err = writeSpecs(mergedSpecs)
+	if err != nil {
 		return OperationCounts{}, nil, err
 	}
 
@@ -416,7 +418,7 @@ func processOneMerge(
 }
 
 // writeSpecs writes all merged specs to disk
-func writeSpecs(mergedSpecs map[string]string, workingDir string) error {
+func writeSpecs(mergedSpecs map[string]string) error {
 	for targetPath, content := range mergedSpecs {
 		if err := os.MkdirAll(
 			filepath.Dir(targetPath),

--- a/internal/archive/types.go
+++ b/internal/archive/types.go
@@ -20,7 +20,7 @@ type OperationCounts struct {
 	Renamed  int
 }
 
-// Add increments the total operation count
+// Total adds up all counts for delta operations.
 func (oc *OperationCounts) Total() int {
 	return oc.Added + oc.Modified + oc.Removed + oc.Renamed
 }

--- a/internal/archive/validator.go
+++ b/internal/archive/validator.go
@@ -45,11 +45,13 @@ func ValidatePostMerge(mergedContent, _ string) error {
 		_ = os.Remove(tmpFile.Name())
 	}()
 
-	if _, err := tmpFile.WriteString(mergedContent); err != nil {
+	_, err = tmpFile.WriteString(mergedContent)
+	if err != nil {
 		return fmt.Errorf("write temp file: %w", err)
 	}
 
-	if err := tmpFile.Close(); err != nil {
+	err = tmpFile.Close()
+	if err != nil {
 		return fmt.Errorf("close temp file: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Fix variable shadowing in `ResolveChangeID` block by declaring result variable before the if statement
- Remove unused `workingDir` parameter from `writeSpecs` function
- Separate error assignments from declarations for better readability in validator.go
- Update `OperationCounts.Total()` comment to be more descriptive
- Refine WHY_SYNC.md wording and add trailing newline

## Test plan
- [ ] Verify `go build ./...` succeeds
- [ ] Verify `go test ./internal/archive/...` passes
- [ ] Run `spectr archive` command to ensure functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sync capability documentation for clarity

* **Refactor**
  * Improved change identification resolution process
  * Enhanced error handling in internal workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->