### PR TITLE
spectr(proposal): add-pr-delete-subcommand

### DIFF
--- a/spectr/changes/add-pr-delete-subcommand/proposal.md
+++ b/spectr/changes/add-pr-delete-subcommand/proposal.md
@@ -1,0 +1,40 @@
+# Change: Add `spectr pr delete` Subcommand
+
+## Why
+
+Users need a quick way to delete specs from the codebase via PR without manually removing directories. The current PR subcommands (`archive` and `new`) focus on creating or promoting changes, but there's no streamlined way to remove a spec when it's no longer needed.
+
+A dedicated `spectr pr delete` (with `d` shorthand) subcommand provides:
+- Single command to create a PR that removes an entire spec directory
+- Complete isolation via git worktrees - user's working directory is never modified
+- Supports partial change IDs consistent with other `spectr pr` subcommands
+- Clear commit messages and PR bodies explaining the deletion
+
+## What Changes
+
+- **NEW**: Add `spectr pr delete <spec-id>` subcommand:
+  - Alias: `spectr pr d <spec-id>`
+  - Creates a worktree branch `spectr/delete-<spec-id>`
+  - Removes the entire `spectr/specs/<spec-id>/` directory in the worktree
+  - Stages deletion, commits with structured message, pushes, creates PR
+  - Cleans up worktree automatically
+
+- **NEW**: Add `PRDeleteCmd` struct in `cmd/pr.go`:
+  - Shares common flags with other PR subcommands: `--base`, `--draft`, `--force`, `--dry-run`
+  - Supports partial spec ID resolution (prefix and substring matching)
+
+- **NEW**: Add `ModeDelete` constant and delete workflow in `internal/pr/`:
+  - `executeDeleteInWorktree()` function to `rm -rf` the spec directory
+  - Delete-specific commit and PR templates
+
+## Impact
+
+- **Affected specs**: `cli-interface` (new subcommand)
+- **Affected code**:
+  - `cmd/pr.go` - Add `Delete` subcommand to `PRCmd` struct
+  - `internal/pr/workflow.go` - Add delete mode handling
+  - `internal/pr/helpers.go` - Add `executeDeleteInWorktree()` function
+  - `internal/pr/templates.go` - Add delete-specific templates
+  - `internal/discovery/specs.go` - May need spec ID resolution (similar to change ID resolution)
+- **User-visible changes**: New `spectr pr delete` and `spectr pr d` commands
+- **Dependencies**: Same as existing `spectr pr` commands (git, platform CLIs)

--- a/spectr/changes/add-pr-delete-subcommand/specs/cli-interface/spec.md
+++ b/spectr/changes/add-pr-delete-subcommand/specs/cli-interface/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: PR Delete Subcommand
+
+The `spectr pr delete` command (alias: `spectr pr d`) SHALL create a pull request that removes an entire spec directory from the codebase using git worktree isolation.
+
+#### Scenario: User deletes a spec via PR
+
+- **WHEN** user runs `spectr pr delete my-spec`
+- **AND** `spectr/specs/my-spec/` exists
+- **THEN** a worktree is created on branch `spectr/delete-my-spec`
+- **AND** the directory `spectr/specs/my-spec/` is removed in the worktree
+- **AND** a commit is created with message "spectr: delete my-spec spec"
+- **AND** the branch is pushed to origin
+- **AND** a PR is created via platform CLI (gh, glab, tea)
+- **AND** the worktree is cleaned up
+- **AND** the PR URL is displayed
+
+#### Scenario: User uses shorthand alias
+
+- **WHEN** user runs `spectr pr d my-spec`
+- **THEN** the behavior is identical to `spectr pr delete my-spec`
+
+#### Scenario: Partial spec ID resolution
+
+- **WHEN** user runs `spectr pr delete cli`
+- **AND** only one spec ID starts with or contains `cli` (e.g., `cli-interface`)
+- **THEN** a message is displayed: "Resolved 'cli' -> 'cli-interface'"
+- **AND** the delete proceeds with the resolved ID
+
+#### Scenario: Ambiguous partial spec ID
+
+- **WHEN** user runs `spectr pr delete val`
+- **AND** multiple spec IDs match `val` (e.g., `validation`, `value-objects`)
+- **THEN** an error is displayed: "Ambiguous ID 'val' matches multiple specs: validation, value-objects"
+- **AND** the command exits with error code 1
+
+#### Scenario: Spec not found
+
+- **WHEN** user runs `spectr pr delete nonexistent`
+- **AND** no spec matches `nonexistent`
+- **THEN** an error is displayed: "No spec found matching 'nonexistent'"
+- **AND** the command exits with error code 1
+
+#### Scenario: Dry run mode
+
+- **WHEN** user runs `spectr pr delete my-spec --dry-run`
+- **THEN** the command displays what would happen without executing
+- **AND** no worktree is created
+- **AND** no files are deleted
+- **AND** no PR is created
+
+#### Scenario: Draft PR mode
+
+- **WHEN** user runs `spectr pr delete my-spec --draft`
+- **THEN** the PR is created as a draft PR
+
+#### Scenario: Force delete existing branch
+
+- **WHEN** user runs `spectr pr delete my-spec --force`
+- **AND** branch `spectr/delete-my-spec` already exists on remote
+- **THEN** the existing remote branch is deleted first
+- **AND** the workflow proceeds normally
+
+#### Scenario: Branch already exists without force
+
+- **WHEN** user runs `spectr pr delete my-spec`
+- **AND** branch `spectr/delete-my-spec` already exists on remote
+- **AND** `--force` flag is not provided
+- **THEN** an error is displayed: "branch 'spectr/delete-my-spec' already exists on remote; use --force to delete"
+- **AND** the command exits with error code 1
+
+#### Scenario: Custom base branch
+
+- **WHEN** user runs `spectr pr delete my-spec --base develop`
+- **THEN** the worktree is based on `develop` branch
+- **AND** the PR targets `develop` instead of the default branch
+
+### Requirement: Delete PR Commit Message Format
+
+The commit message for spec deletion PRs SHALL follow a structured format that clearly identifies the deletion operation.
+
+#### Scenario: Delete commit message format
+
+- **WHEN** a delete PR commit is created
+- **THEN** the commit message SHALL be: "spectr: delete <spec-id> spec"
+- **AND** the commit body SHALL include the spec ID being deleted
+
+### Requirement: Delete PR Body Format
+
+The PR body for spec deletion PRs SHALL clearly explain the deletion operation.
+
+#### Scenario: Delete PR body content
+
+- **WHEN** a delete PR is created
+- **THEN** the PR title SHALL be: "spectr: Delete <spec-id> spec"
+- **AND** the PR body SHALL include a summary section explaining the deletion
+- **AND** the PR body SHALL list the spec being removed

--- a/spectr/changes/add-pr-delete-subcommand/tasks.md
+++ b/spectr/changes/add-pr-delete-subcommand/tasks.md
@@ -1,0 +1,31 @@
+## 1. Infrastructure
+
+- [ ] 1.1 Add `ModeDelete` constant to `internal/pr/workflow.go`
+- [ ] 1.2 Add spec ID resolution to `internal/discovery/specs.go` (similar to `ResolveChangeID`)
+
+## 2. Delete Workflow Implementation
+
+- [ ] 2.1 Add `executeDeleteInWorktree()` function to `internal/pr/helpers.go`
+- [ ] 2.2 Add delete case to `executeOperation()` in `internal/pr/workflow.go`
+- [ ] 2.3 Add delete-specific commit message template to `internal/pr/templates.go`
+- [ ] 2.4 Add delete-specific PR body template to `internal/pr/templates.go`
+
+## 3. CLI Integration
+
+- [ ] 3.1 Add `PRDeleteCmd` struct to `cmd/pr.go` with flags: `Base`, `Draft`, `Force`, `DryRun`
+- [ ] 3.2 Add `Delete` field to `PRCmd` struct with `cmd:"" aliases:"d"` tag
+- [ ] 3.3 Implement `Run()` method on `PRDeleteCmd` with spec ID resolution
+- [ ] 3.4 Update `validatePrerequisites()` to handle delete mode (validate spec exists instead of change)
+
+## 4. Testing
+
+- [ ] 4.1 Add unit tests for `ResolveSpecID()` function
+- [ ] 4.2 Add unit tests for delete templates
+- [ ] 4.3 Add workflow tests for delete mode
+- [ ] 4.4 Manual testing: `spectr pr delete <spec-id>` and `spectr pr d <spec-id>`
+
+## 5. Validation
+
+- [ ] 5.1 Run `spectr validate add-pr-delete-subcommand --strict`
+- [ ] 5.2 Run existing tests to ensure no regressions
+- [ ] 5.3 Run linter (`golangci-lint run`)


### PR DESCRIPTION
## Summary

Proposal for review: `add-pr-delete-subcommand`

**Location**: `spectr/changes/add-pr-delete-subcommand/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr new`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added proposal, specification, and implementation roadmap for the upcoming `spectr pr delete` subcommand (alias: `spectr pr d`). This feature will automate spec deletion workflows using isolated git worktrees, with support for draft mode, dry-run testing, force deletion, and partial spec ID resolution—preserving your working directory throughout the process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->