### PR TITLE
spectr(proposal): add-pr-archive-alias

### DIFF
--- a/spectr/changes/add-pr-archive-alias/proposal.md
+++ b/spectr/changes/add-pr-archive-alias/proposal.md
@@ -1,0 +1,16 @@
+# Change: Add `a` alias for `spectr pr archive` subcommand
+
+## Why
+Users frequently run `spectr pr archive <id>` to create PRs for completed changes. Providing a shorthand `spectr pr a <id>` reduces typing and improves CLI ergonomics, consistent with common CLI patterns where single-letter aliases exist for frequently-used subcommands.
+
+## What Changes
+- Add `a` as an alias for the `archive` subcommand under `spectr pr`
+- Users can invoke `spectr pr a <id>` as equivalent to `spectr pr archive <id>`
+- All existing flags (`--base`, `--draft`, `--force`, `--dry-run`, `--skip-specs`) work with the alias
+
+## Dependencies
+- Requires `add-pr-subcommand` to be archived first (PR Command Structure must exist in base specs)
+
+## Impact
+- Affected specs: `cli-interface`
+- Affected code: `cmd/pr.go` (single line change to add `aliases:"a"` tag)

--- a/spectr/changes/add-pr-archive-alias/specs/cli-interface/spec.md
+++ b/spectr/changes/add-pr-archive-alias/specs/cli-interface/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: PR Archive Subcommand Alias
+The `spectr pr archive` subcommand SHALL support `a` as a shorthand alias, allowing users to invoke `spectr pr a <id>` as equivalent to `spectr pr archive <id>`.
+
+#### Scenario: User runs spectr pr a shorthand
+- **WHEN** user runs `spectr pr a <change-id>`
+- **THEN** the system executes the archive PR workflow identically to `spectr pr archive`
+- **AND** all flags (`--base`, `--draft`, `--force`, `--dry-run`, `--skip-specs`) work with the alias
+
+#### Scenario: User runs spectr pr a with flags
+- **WHEN** user runs `spectr pr a my-change --draft --force`
+- **THEN** the command behaves identically to `spectr pr archive my-change --draft --force`
+- **AND** a draft PR is created after deleting any existing branch
+
+#### Scenario: Help text shows archive alias
+- **WHEN** user runs `spectr pr --help`
+- **THEN** the help text displays `archive` with its `a` alias
+- **AND** the alias is shown in parentheses or as comma-separated alternatives

--- a/spectr/changes/add-pr-archive-alias/tasks.md
+++ b/spectr/changes/add-pr-archive-alias/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [ ] 1.1 Add `aliases:"a"` tag to `PRArchiveCmd` struct in `cmd/pr.go`
+- [ ] 1.2 Add test case verifying `spectr pr a <id>` works identically to `spectr pr archive <id>`
+- [ ] 1.3 Verify help text shows alias in command listing


### PR DESCRIPTION
## Summary

Proposal for review: `add-pr-archive-alias`

**Location**: `spectr/changes/add-pr-archive-alias/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr new`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single-letter alias `a` for `spectr pr archive`, so `spectr pr a <id>` is equivalent to `spectr pr archive <id>` and supports all existing flags (`--base`, `--draft`, `--force`, `--dry-run`, `--skip-specs`).

* **Documentation**
  * Help text and CLI docs updated to show the new alias alongside the archive command.

* **Tests**
  * Added a test to verify the alias behaves identically to the full command.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->