### PR TITLE
feat(pr): use mode-specific branch naming for PR workflows

### DIFF
--- a/internal/pr/workflow.go
+++ b/internal/pr/workflow.go
@@ -96,7 +96,19 @@ func prepareWorkflowContext(config PRConfig) (*workflowContext, error) {
 		return nil, fmt.Errorf("determine base branch: %w", err)
 	}
 
-	branchName := fmt.Sprintf("spectr/%s", config.ChangeID)
+	// Generate mode-specific branch name:
+	// - archive mode: spectr/archive/<change-id>
+	// - new mode: spectr/proposal/<change-id>
+	var branchPrefix string
+	switch config.Mode {
+	case ModeArchive:
+		branchPrefix = "spectr/archive"
+	case ModeNew:
+		branchPrefix = "spectr/proposal"
+	default:
+		branchPrefix = "spectr"
+	}
+	branchName := fmt.Sprintf("%s/%s", branchPrefix, config.ChangeID)
 
 	// Handle existing branch
 	if err := handleExistingBranch(config, branchName); err != nil {

--- a/internal/pr/workflow_test.go
+++ b/internal/pr/workflow_test.go
@@ -104,10 +104,10 @@ func TestPRResult_Struct(t *testing.T) {
 		result PRResult
 	}{
 		{
-			name: "full result",
+			name: "full result - archive mode",
 			result: PRResult{
 				PRURL:       "https://github.com/owner/repo/pull/123",
-				BranchName:  "spectr/add-feature-x",
+				BranchName:  "spectr/archive/add-feature-x",
 				ArchivePath: "spectr/changes/archive/2024-01-15-add-feature-x/",
 				Counts: archive.OperationCounts{
 					Added:    3,
@@ -120,10 +120,10 @@ func TestPRResult_Struct(t *testing.T) {
 			},
 		},
 		{
-			name: "bitbucket result with manual URL",
+			name: "bitbucket result with manual URL - proposal mode",
 			result: PRResult{
 				PRURL:       "",
-				BranchName:  "spectr/new-feature",
+				BranchName:  "spectr/proposal/new-feature",
 				ArchivePath: "",
 				Counts:      archive.OperationCounts{},
 				Platform:    git.PlatformBitbucket,
@@ -131,9 +131,9 @@ func TestPRResult_Struct(t *testing.T) {
 			},
 		},
 		{
-			name: "minimal result",
+			name: "minimal result - proposal mode",
 			result: PRResult{
-				BranchName: "spectr/minimal",
+				BranchName: "spectr/proposal/minimal",
 				Platform:   git.PlatformGitLab,
 			},
 		},
@@ -532,7 +532,7 @@ func TestWorkflowContext_Struct(t *testing.T) {
 		ctx  workflowContext
 	}{
 		{
-			name: "github context",
+			name: "github context - archive mode",
 			ctx: workflowContext{
 				platformInfo: git.PlatformInfo{
 					Platform: git.PlatformGitHub,
@@ -540,11 +540,11 @@ func TestWorkflowContext_Struct(t *testing.T) {
 					RepoURL:  "https://github.com/owner/repo",
 				},
 				baseBranch: "origin/main",
-				branchName: "spectr/add-feature",
+				branchName: "spectr/archive/add-feature",
 			},
 		},
 		{
-			name: "gitlab context",
+			name: "gitlab context - proposal mode",
 			ctx: workflowContext{
 				platformInfo: git.PlatformInfo{
 					Platform: git.PlatformGitLab,
@@ -552,7 +552,7 @@ func TestWorkflowContext_Struct(t *testing.T) {
 					RepoURL:  "https://gitlab.com/group/project",
 				},
 				baseBranch: "origin/develop",
-				branchName: "spectr/new-proposal",
+				branchName: "spectr/proposal/new-proposal",
 			},
 		},
 	}

--- a/spectr/changes/fix-pr-branch-naming/proposal.md
+++ b/spectr/changes/fix-pr-branch-naming/proposal.md
@@ -1,0 +1,19 @@
+# Change: Fix PR Branch Naming by Subcommand Type
+
+## Why
+
+Currently, both `spectr pr archive` and `spectr pr new` create branches with the same naming pattern `spectr/<change-id>`. This makes it difficult to distinguish between branches created for archived changes versus proposal reviews when viewing git history or branch lists. The branch name should convey the purpose of the PR at a glance.
+
+## What Changes
+
+- `spectr pr archive` creates branches named `spectr/archive/<change-id>`
+- `spectr pr new` creates branches named `spectr/proposal/<change-id>`
+- Update branch existence checks to use mode-specific prefix
+- Update existing spec scenarios to reflect new branch naming
+
+## Impact
+
+- Affected specs: cli-interface (adds PR Branch Naming Convention requirement)
+- Affected code: `internal/pr/workflow.go:99` (branch name generation in `prepareWorkflowContext`)
+- Related changes: Supersedes branch naming in `add-pr-subcommand` change which uses `spectr/<change-id>` format
+- **BREAKING**: Users with existing remote branches named `spectr/<change-id>` will need to use `--force` to recreate them with the new naming convention, or delete them manually

--- a/spectr/changes/fix-pr-branch-naming/specs/cli-interface/spec.md
+++ b/spectr/changes/fix-pr-branch-naming/specs/cli-interface/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: PR Branch Naming Convention
+The system SHALL use a mode-specific branch naming convention for PR branches that distinguishes between archive and proposal branches based on the subcommand used.
+
+#### Scenario: Archive branch name format
+- **WHEN** user runs `spectr pr archive <change-id>`
+- **THEN** the branch is named `spectr/archive/<change-id>`
+
+#### Scenario: Proposal branch name format
+- **WHEN** user runs `spectr pr new <change-id>`
+- **THEN** the branch is named `spectr/proposal/<change-id>`
+
+#### Scenario: Branch name with special characters
+- **WHEN** change ID contains only valid kebab-case characters
+- **THEN** the branch name is valid for git
+
+#### Scenario: Branch names clearly indicate PR purpose
+- **WHEN** a developer views the branch list
+- **THEN** they can distinguish archive PRs from proposal PRs by the branch prefix
+- **AND** `spectr/archive/*` indicates a completed change being archived
+- **AND** `spectr/proposal/*` indicates a change proposal for review
+
+#### Scenario: Force flag for existing archive branch
+- **WHEN** user runs `spectr pr archive <change-id> --force`
+- **AND** branch `spectr/archive/<change-id>` already exists on remote
+- **THEN** the existing branch is deleted and recreated
+- **AND** the PR workflow proceeds normally
+
+#### Scenario: Force flag for existing proposal branch
+- **WHEN** user runs `spectr pr new <change-id> --force`
+- **AND** branch `spectr/proposal/<change-id>` already exists on remote
+- **THEN** the existing branch is deleted and recreated
+- **AND** the PR workflow proceeds normally
+
+#### Scenario: Archive branch conflict without force
+- **WHEN** user runs `spectr pr archive <change-id>`
+- **AND** branch `spectr/archive/<change-id>` already exists on remote
+- **AND** `--force` flag is NOT provided
+- **THEN** an error is displayed: "branch 'spectr/archive/<change-id>' already exists on remote; use --force to delete"
+- **AND** the command exits with code 1
+
+#### Scenario: Proposal branch conflict without force
+- **WHEN** user runs `spectr pr new <change-id>`
+- **AND** branch `spectr/proposal/<change-id>` already exists on remote
+- **AND** `--force` flag is NOT provided
+- **THEN** an error is displayed: "branch 'spectr/proposal/<change-id>' already exists on remote; use --force to delete"
+- **AND** the command exits with code 1

--- a/spectr/changes/fix-pr-branch-naming/tasks.md
+++ b/spectr/changes/fix-pr-branch-naming/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+
+- [x] 1.1 Update `prepareWorkflowContext` in `internal/pr/workflow.go` to generate mode-specific branch names
+- [x] 1.2 Update `internal/pr/workflow_test.go` test cases to expect new branch naming patterns
+- [x] 1.3 Run `go test ./internal/pr/...` to verify tests pass
+
+## 2. Validation
+
+- [x] 2.1 Run `spectr validate fix-pr-branch-naming --strict` to ensure proposal is valid
+- [x] 2.2 Run `go build ./...` to verify code compiles


### PR DESCRIPTION
## Summary

- Updates `spectr pr archive` to create branches named `spectr/archive/<change-id>`
- Updates `spectr pr new` to create branches named `spectr/proposal/<change-id>`
- Makes it easier to distinguish between branches created for archived changes versus proposal reviews

## Changes

- Modified `prepareWorkflowContext` in `internal/pr/workflow.go` to generate mode-specific branch names based on the PR mode
- Updated test cases in `internal/pr/workflow_test.go` to reflect the new naming patterns

## Test plan

- [x] `go test ./internal/pr/...` passes
- [x] `go build ./...` compiles successfully
- [x] `spectr validate fix-pr-branch-naming --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR branch names now include mode-specific prefixes: `spectr/archive/<change-id>` for archive mode and `spectr/proposal/<change-id>` for new/proposal mode.

* **Breaking Changes**
  * Existing remote branches must be recreated with `--force` or deleted to adopt the new naming convention.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->