### PR TITLE
spectr(proposal): add-uncommitted-filter-hotkey

### DIFF
--- a/spectr/changes/add-uncommitted-filter-hotkey/proposal.md
+++ b/spectr/changes/add-uncommitted-filter-hotkey/proposal.md
@@ -1,0 +1,31 @@
+# Change: Add Uncommitted Filter Hotkey
+
+## Summary
+
+Add an 'h' hotkey to the `spectr list -I` interactive TUI that filters the list to show only:
+1. Changes with uncommitted git modifications (files in the change directory have uncommitted changes)
+2. Changes with fully completed tasks.md files (all tasks marked complete)
+
+This helps users quickly identify changes that are ready to be committed or archived.
+
+## Motivation
+
+When working with multiple active changes, it can be difficult to identify which changes:
+- Have local modifications that need to be committed to git
+- Have all tasks completed and are ready for archive
+
+The 'h' hotkey ("harvestable" or "ready to handle") provides a quick filter to surface these actionable changes.
+
+## Scope
+
+- Add 'h' hotkey to the interactive list TUI
+- Implement git status checking for change directories
+- Add filtering logic for uncommitted changes with complete tasks
+- Toggle behavior: press 'h' to enable filter, press again to disable
+- Update help text to include the new hotkey
+
+## Non-Goals
+
+- Modifying the non-interactive list output
+- Adding similar functionality to specs list mode
+- Automatic git operations (commit, push, etc.)

--- a/spectr/changes/add-uncommitted-filter-hotkey/specs/cli-interface/spec.md
+++ b/spectr/changes/add-uncommitted-filter-hotkey/specs/cli-interface/spec.md
@@ -1,0 +1,68 @@
+# Cli Interface Specification
+
+## ADDED Requirements
+
+### Requirement: Uncommitted Filter Hotkey in Interactive Changes Mode
+
+The interactive changes list mode SHALL provide an 'h' hotkey that toggles a filter to show only changes that have uncommitted git modifications AND fully completed tasks.md files. This helps users identify changes that are ready to be committed or archived.
+
+#### Scenario: User presses 'h' to enable uncommitted filter
+- **WHEN** user is in interactive changes mode (`spectr list -I`)
+- **AND** user presses the 'h' key
+- **THEN** the table is filtered to show only changes where:
+  - The change directory has uncommitted git modifications (untracked or modified files)
+  - AND all tasks in tasks.md are marked complete (Completed == Total, with Total > 0)
+- **AND** the footer updates to indicate filter is active (e.g., "filter: uncommitted+complete")
+- **AND** the item count updates to reflect filtered results
+
+#### Scenario: User presses 'h' again to disable filter
+- **WHEN** uncommitted filter is active
+- **AND** user presses the 'h' key
+- **THEN** the filter is disabled
+- **AND** all changes are displayed again
+- **AND** the footer returns to normal display
+- **AND** the cursor position is preserved if the previously selected item is still visible
+
+#### Scenario: No changes match filter criteria
+- **WHEN** user presses 'h' to enable filter
+- **AND** no changes have both uncommitted modifications and complete tasks
+- **THEN** the table displays no rows
+- **AND** a message indicates "No uncommitted changes with complete tasks"
+- **AND** user can press 'h' again to show all changes
+
+#### Scenario: Git status detection for change directory
+- **WHEN** the filter checks for uncommitted modifications
+- **THEN** it runs `git status --porcelain` for the change directory
+- **AND** considers a change "uncommitted" if any files in `spectr/changes/<id>/` appear in git status output
+- **AND** includes both untracked files and modified files
+
+#### Scenario: Complete tasks detection
+- **WHEN** the filter checks for complete tasks
+- **THEN** a change is considered "complete" if TaskStatus.Completed == TaskStatus.Total
+- **AND** TaskStatus.Total must be greater than 0 (empty tasks.md does not count as complete)
+
+#### Scenario: Help text shows uncommitted filter hotkey
+- **WHEN** user presses '?' to show help in changes mode
+- **THEN** the help text includes 'h: uncommitted' or 'h: filter uncommitted'
+- **AND** the hotkey appears in the controls line
+
+#### Scenario: Filter not available in specs mode
+- **WHEN** user is in interactive specs mode (`spectr list --specs -I`)
+- **AND** user presses 'h' key
+- **THEN** the key press is ignored (no action taken)
+- **AND** the help text does NOT show 'h' option
+- **AND** specs do not have git status or tasks concepts
+
+#### Scenario: Filter available in unified mode for changes only
+- **WHEN** user is in unified interactive mode (`spectr list --all -I`)
+- **AND** user presses 'h' key
+- **THEN** the filter applies only to change items
+- **AND** specs are hidden when filter is active (since they cannot match criteria)
+- **AND** the filter can be toggled on/off as in changes mode
+
+#### Scenario: Search and uncommitted filter work together
+- **WHEN** uncommitted filter is active
+- **AND** user activates search mode with '/'
+- **THEN** search operates on the already-filtered (uncommitted+complete) changes
+- **AND** both filters combine to narrow results
+- **AND** clearing search restores the uncommitted filter view

--- a/spectr/changes/add-uncommitted-filter-hotkey/tasks.md
+++ b/spectr/changes/add-uncommitted-filter-hotkey/tasks.md
@@ -1,0 +1,37 @@
+# Tasks
+
+## Implementation
+
+- [ ] Add `HasUncommittedChanges(changeDir string) bool` function in `internal/discovery/changes.go` that uses `git status --porcelain` to detect uncommitted files in a change directory
+- [ ] Add `uncommittedFilter bool` field to `interactiveModel` struct in `internal/list/interactive.go`
+- [ ] Add `uncommittedChanges map[string]bool` field to cache git status results for performance
+- [ ] Implement `handleUncommittedFilter()` method to toggle the filter state
+- [ ] Add 'h' key handler in the `Update()` method that calls `handleUncommittedFilter()`
+- [ ] Implement `applyUncommittedFilter()` method that filters `allRows` based on:
+  - Git uncommitted status (from cached map)
+  - Complete tasks (TaskStatus.Completed == TaskStatus.Total && Total > 0)
+- [ ] Update help text in `RunInteractiveChanges()` to include `h: uncommitted`
+- [ ] Update help text in `RunInteractiveAll()` to include `h: uncommitted`
+- [ ] Update minimal footer to show "filter: uncommitted+complete" when filter is active
+- [ ] Add handling for empty filter results (display "No uncommitted changes with complete tasks")
+- [ ] Ignore 'h' key press in specs-only mode (`itemTypeSpec`)
+- [ ] Ensure search filter and uncommitted filter work together correctly
+
+## Testing
+
+- [ ] Add unit test for `HasUncommittedChanges()` function with mock git output
+- [ ] Add test for uncommitted filter toggle behavior in interactive model
+- [ ] Add test for filter criteria (uncommitted AND complete tasks)
+- [ ] Add test for empty filter results message
+- [ ] Add test that 'h' is ignored in specs mode
+- [ ] Add test for combined search + uncommitted filter
+- [ ] Run `go test ./internal/list/...` to verify all tests pass
+- [ ] Run `go test ./internal/discovery/...` to verify discovery tests pass
+
+## Validation
+
+- [ ] Run `spectr validate add-uncommitted-filter-hotkey --strict` to verify spec compliance
+- [ ] Manual test: Run `spectr list -I`, press 'h' with changes that have uncommitted modifications
+- [ ] Manual test: Verify filter toggles off when pressing 'h' again
+- [ ] Manual test: Verify help text shows 'h' hotkey after pressing '?'
+- [ ] Manual test: Verify 'h' is ignored in `spectr list --specs -I`


### PR DESCRIPTION
## Summary

Proposal for review: `add-uncommitted-filter-hotkey`

**Location**: `spectr/changes/add-uncommitted-filter-hotkey/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added "h" hotkey in interactive changes mode to toggle a filter displaying only changes with uncommitted git modifications and completed tasks, with updated help text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->