### PR TITLE
ci: add nix build check to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,25 @@ jobs:
 
       - name: Check Nix formatting (alejandra)
         run: nix develop .#ci -c alejandra --check .
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v24
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: Build with Nix
+        run: nix build .#


### PR DESCRIPTION
## Summary
- Add a new `build` job to the CI workflow that runs `nix build .#`
- Ensures the Nix package builds successfully on every push and PR
- Follows the same pattern as existing CI jobs (checkout, Nix install, cache, run)

## Test plan
- [ ] Verify the new `build` job runs successfully in CI
- [ ] Confirm `nix build .#` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)