### PR TITLE
spectr(proposal): add-code-of-conduct

### DIFF
--- a/spectr/changes/add-code-of-conduct/proposal.md
+++ b/spectr/changes/add-code-of-conduct/proposal.md
@@ -1,0 +1,14 @@
+# Change: Add Code of Conduct
+
+## Why
+Spectr currently lacks a formal code of conduct. As an open-source project, establishing clear community standards ensures contributors understand behavioral expectations and creates a welcoming environment for all participants.
+
+## What Changes
+- Add `CODE_OF_CONDUCT.md` to the repository root
+- Adopt guidelines inspired by Ladybird Browser / Ruby Community Conduct Guideline
+- Focus on tolerance, respectful communication, assuming good intentions, and zero tolerance for harassment
+
+## Impact
+- Affected specs: New `community-guidelines` capability
+- Affected code: None (documentation only)
+- Breaking changes: None

--- a/spectr/changes/add-code-of-conduct/specs/community-guidelines/spec.md
+++ b/spectr/changes/add-code-of-conduct/specs/community-guidelines/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Code of Conduct Document
+The project SHALL provide a `CODE_OF_CONDUCT.md` file in the repository root that establishes community behavioral standards.
+
+#### Scenario: Code of conduct file exists
+- **WHEN** a user navigates to the repository root
+- **THEN** a `CODE_OF_CONDUCT.md` file SHALL be present
+
+### Requirement: Tolerance Guideline
+The code of conduct SHALL require participants to be tolerant of opposing views.
+
+#### Scenario: Tolerance statement present
+- **WHEN** reading the code of conduct
+- **THEN** the document SHALL include guidance on tolerating opposing views
+
+### Requirement: Respectful Communication Guideline
+The code of conduct SHALL require participants to keep language and actions free of personal attacks and disparaging remarks.
+
+#### Scenario: Personal attacks prohibition present
+- **WHEN** reading the code of conduct
+- **THEN** the document SHALL prohibit personal attacks and disparaging personal remarks
+
+### Requirement: Good Faith Assumption Guideline
+The code of conduct SHALL require participants to assume good intentions when interpreting others' words and actions.
+
+#### Scenario: Good faith assumption present
+- **WHEN** reading the code of conduct
+- **THEN** the document SHALL include guidance on assuming good intentions
+
+### Requirement: Anti-Harassment Guideline
+The code of conduct SHALL prohibit behavior that can reasonably be considered harassment.
+
+#### Scenario: Harassment prohibition present
+- **WHEN** reading the code of conduct
+- **THEN** the document SHALL state that harassment will not be tolerated
+
+### Requirement: Attribution
+The code of conduct SHALL include attribution to its source inspiration (Ruby Community Conduct Guideline).
+
+#### Scenario: Attribution present
+- **WHEN** reading the code of conduct
+- **THEN** the document SHALL credit the Ruby Community Conduct Guideline as source inspiration

--- a/spectr/changes/add-code-of-conduct/tasks.md
+++ b/spectr/changes/add-code-of-conduct/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+- [ ] 1.1 Create `CODE_OF_CONDUCT.md` in repository root with Ladybird/Ruby-inspired guidelines
+- [ ] 1.2 Add attribution to Ruby Community Conduct Guideline and Ladybird Browser
+
+## 2. Validation
+- [ ] 2.1 Verify file exists and content is complete
+- [ ] 2.2 Run `spectr validate add-code-of-conduct --strict`


### PR DESCRIPTION
## Summary
- Add a code of conduct proposal inspired by Ladybird Browser and the Ruby Community Conduct Guideline
- Proposal includes spec deltas for `community-guidelines` capability with 6 requirements
- Guidelines cover tolerance, respectful communication, good faith assumptions, and anti-harassment

## Proposal Details
The code of conduct will establish community standards:
1. Participants will be tolerant of opposing views
2. Language and actions must be free of personal attacks and disparaging remarks
3. Assume good intentions when interpreting others' words and actions
4. Harassment will not be tolerated

## Test plan
- [x] Proposal validated with `spectr validate add-code-of-conduct --strict`
- [ ] Review proposal content for completeness
- [ ] Approve for implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a Code of Conduct establishing community guidelines for participation.
  * Guidelines emphasize tolerance of diverse viewpoints, respectful communication, good faith assumptions, and a harassment-free environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->