### PR TITLE
spectr(proposal): remove-init-readme-creation

### DIFF
--- a/spectr/changes/remove-init-readme-creation/proposal.md
+++ b/spectr/changes/remove-init-readme-creation/proposal.md
@@ -1,0 +1,18 @@
+# Change: Remove automatic README creation during spectr init
+
+## Why
+
+The `spectr init` command currently creates a README.md file automatically when one doesn't exist. This behavior is overly opinionated - most projects either already have a README or have specific preferences about their README content and structure. Auto-generating a README can be annoying for users who want control over their project documentation.
+
+## What Changes
+
+- **Remove automatic README creation** during `spectr init`
+- Remove the `createReadmeIfMissing` function from the init executor
+- Remove the README creation step from the `Execute` method
+
+## Impact
+
+- Affected specs: `cli-interface`
+- Affected code: `internal/initialize/executor.go`
+- No breaking changes - users who want a README can create their own
+- Simplifies the init process by focusing on Spectr-specific files only

--- a/spectr/changes/remove-init-readme-creation/specs/cli-interface/spec.md
+++ b/spectr/changes/remove-init-readme-creation/specs/cli-interface/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Initialization Next Steps Message
+
+The `spectr init` command SHALL display a formatted "Next steps" message after successful initialization that provides users with clear, actionable guidance for getting started with Spectr.
+
+The message SHALL include:
+1. Three progressive steps with copy-paste ready prompts for AI assistants
+2. Visual separators to make the message stand out
+3. References to key Spectr files and documentation
+4. Placeholder text that users can customize (e.g., "[YOUR FEATURE HERE]")
+
+The init command SHALL NOT automatically create project files outside the `spectr/` directory (such as README.md). Users maintain full control over their project's root-level documentation.
+
+#### Scenario: Interactive mode initialization succeeds
+
+- **WHEN** a user completes initialization via the interactive TUI wizard
+- **THEN** the completion screen SHALL display the next steps message
+- **AND** the message SHALL appear after the list of created/updated files
+- **AND** the message SHALL be visually distinct with a separator line
+- **AND** the message SHALL provide three numbered steps with specific prompts
+
+#### Scenario: Non-interactive mode initialization succeeds
+
+- **WHEN** a user runs `spectr init --non-interactive` and initialization succeeds
+- **THEN** the command output SHALL display the next steps message
+- **AND** the message SHALL appear after the list of created/updated files
+- **AND** the message SHALL be formatted consistently with the interactive mode
+- **AND** the message SHALL include the same three progressive steps
+
+#### Scenario: Initialization fails with errors
+
+- **WHEN** initialization fails with errors
+- **THEN** the next steps message SHALL NOT be displayed
+- **AND** only error messages SHALL be shown
+
+#### Scenario: Next steps message content
+
+- **WHEN** the next steps message is displayed
+- **THEN** step 1 SHALL guide users to populate spectr/project.md
+- **AND** step 2 SHALL guide users to create their first change proposal
+- **AND** step 3 SHALL guide users to learn the Spectr workflow from spectr/AGENTS.md
+- **AND** each step SHALL include a complete, copy-paste ready prompt in quotes
+- **AND** the message SHALL include a visual separator using dashes or similar characters
+
+#### Scenario: Init does not create README
+
+- **WHEN** a user runs `spectr init` on a project without a README.md
+- **THEN** the init command SHALL NOT create a README.md file
+- **AND** only files within the `spectr/` directory SHALL be created
+- **AND** tool-specific files (e.g., CLAUDE.md, .cursor/) SHALL be created as configured

--- a/spectr/changes/remove-init-readme-creation/tasks.md
+++ b/spectr/changes/remove-init-readme-creation/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+- [ ] 1.1 Remove the README creation step (lines 110-117) from the `Execute` method in `internal/initialize/executor.go`
+- [ ] 1.2 Remove the `createReadmeIfMissing` function (lines 296-339) from `internal/initialize/executor.go`
+
+## 2. Validation
+
+- [ ] 2.1 Run `go build` to verify compilation
+- [ ] 2.2 Run `go test ./internal/initialize/...` to verify tests pass


### PR DESCRIPTION
## Summary

Proposal for review: `remove-init-readme-creation`

**Location**: `spectr/changes/remove-init-readme-creation/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-initialization guidance displaying next steps and copy-paste ready prompts after successful `spectr init`.

* **Changes**
  * Removed automatic README.md creation during initialization; now only Spectr-specific files are generated in the spectr/ directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->