### PR TITLE
spectr(apply): remove-init-readme-creation

### DIFF
--- a/internal/initialize/executor.go
+++ b/internal/initialize/executor.go
@@ -107,15 +107,6 @@ func (e *InitExecutor) Execute(
 		)
 	}
 
-	// 6. Create README if it doesn't exist
-	err = e.createReadmeIfMissing(result)
-	if err != nil {
-		result.Errors = append(
-			result.Errors,
-			fmt.Sprintf("failed to create README: %v", err),
-		)
-	}
-
 	return result, nil
 }
 
@@ -291,49 +282,4 @@ Next steps:
 
 ────────────────────────────────────────────────────────────────
 `
-}
-
-// createReadmeIfMissing creates a basic README.md if it doesn't exist
-func (e *InitExecutor) createReadmeIfMissing(result *ExecutionResult) error {
-	readmePath := filepath.Join(e.projectPath, "README.md")
-
-	// Only create if it doesn't exist
-	if FileExists(readmePath) {
-		return nil
-	}
-
-	// Get project name
-	projectName := filepath.Base(e.projectPath)
-
-	content := fmt.Sprintf(`# %s
-
-This project uses [Spectr](https://spectr.dev) for structured development and change management.
-
-## Getting Started
-
-1. Review the project documentation in `+"`spectr/project.md`"+`
-2. Explore the Spectr documentation: https://spectr.dev
-3. Create your first change proposal: `+"`spectr proposal <change-name>`"+`
-
-## Spectr Commands
-
-- `+"`spectr proposal <name>`"+` - Create a new change proposal
-- `+"`spectr apply <change-id>`"+` - Apply an approved change
-- `+"`spectr archive <change-id>`"+` - Archive a deployed change
-
-## Documentation
-
-- [Project Overview](spectr/project.md)
-- [AI Agent Instructions](spectr/AGENTS.md)
-- [Specifications](spectr/specs/)
-- [Change Proposals](spectr/changes/)
-`, projectName)
-
-	if err := os.WriteFile(readmePath, []byte(content), 0644); err != nil {
-		return fmt.Errorf("failed to create README.md: %w", err)
-	}
-
-	result.CreatedFiles = append(result.CreatedFiles, "README.md")
-
-	return nil
 }

--- a/spectr/changes/remove-init-readme-creation/tasks.md
+++ b/spectr/changes/remove-init-readme-creation/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Implementation
 
-- [ ] 1.1 Remove the README creation step (lines 110-117) from the `Execute` method in `internal/initialize/executor.go`
-- [ ] 1.2 Remove the `createReadmeIfMissing` function (lines 296-339) from `internal/initialize/executor.go`
+- [x] 1.1 Remove the README creation step (lines 110-117) from the `Execute` method in `internal/initialize/executor.go`
+- [x] 1.2 Remove the `createReadmeIfMissing` function (lines 296-339) from `internal/initialize/executor.go`
 
 ## 2. Validation
 
-- [ ] 2.1 Run `go build` to verify compilation
-- [ ] 2.2 Run `go test ./internal/initialize/...` to verify tests pass
+- [x] 2.1 Run `go build` to verify compilation
+- [x] 2.2 Run `go test ./internal/initialize/...` to verify tests pass


### PR DESCRIPTION
## Summary

- Removed automatic README.md creation during `spectr init` 
- Removed the `createReadmeIfMissing` function from `internal/initialize/executor.go`
- Removed README creation step from the `Execute` method
- Updated `tasks.md` to mark all implementation and validation tasks complete

## Rationale

The `spectr init` command was automatically creating a README.md file when one didn't exist. This behavior is overly opinionated - most projects either already have a README or have specific preferences about their README content and structure. Removing this allows users full control over their project documentation while keeping `spectr init` focused on Spectr-specific files only.

## Test Plan

- [x] Go build verification passed
- [x] All tests in `./internal/initialize/...` pass
- [x] Verified no references to `createReadmeIfMissing` remain in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)