### PR TITLE
spectr(proposal): add-ci-workflow-init-option

### DIFF
--- a/spectr/changes/add-ci-workflow-init-option/proposal.md
+++ b/spectr/changes/add-ci-workflow-init-option/proposal.md
@@ -1,0 +1,23 @@
+# Change: Add CI Workflow Setup Option to Init Wizard
+
+## Why
+Users currently need to manually set up the `.github/workflows/spectr-ci.yml` file to enable automated Spectr validation in their CI/CD pipeline. This is an extra step that many users may not know about or may forget. Adding a checkbox in the init wizard's TUI to optionally create this workflow file provides a seamless onboarding experience and encourages best practices for CI integration.
+
+## What Changes
+- Add a new step or option in the init wizard TUI to ask users if they want to set up GitHub Actions CI workflow
+- When selected, create `.github/workflows/spectr-ci.yml` with the standard Spectr validation job configuration
+- The option should be presented clearly with a brief explanation of what it does
+- The workflow file should follow the existing ci-integration spec requirements (full history checkout, concurrency management, etc.)
+- Skip this option if `.github/workflows/spectr-ci.yml` already exists (treat as already configured)
+
+## Impact
+- Affected specs: `cli-interface` (MODIFIED - init wizard functionality)
+- Affected code:
+  - `internal/initialize/wizard.go` - Add CI workflow step or option to the TUI
+  - `internal/initialize/executor.go` - Add CI workflow file creation logic
+  - `internal/initialize/templates.go` - Add CI workflow template
+- Breaking changes: None (additive feature)
+- Benefits:
+  - Reduces onboarding friction for users who want CI validation
+  - Promotes best practices by making CI setup visible and easy
+  - Maintains consistency with existing init wizard patterns

--- a/spectr/changes/add-ci-workflow-init-option/specs/cli-interface/spec.md
+++ b/spectr/changes/add-ci-workflow-init-option/specs/cli-interface/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: CI Workflow Setup Option in Init Wizard
+The initialization wizard SHALL provide an optional checkbox to create a GitHub Actions workflow file (`.github/workflows/spectr-ci.yml`) for automated Spectr validation during CI/CD. This option integrates seamlessly with the existing tool selection step.
+
+#### Scenario: CI workflow option displayed in tool selection
+- **WHEN** user runs `spectr init` and reaches the tool selection screen
+- **THEN** a "GitHub Actions CI Workflow" option is displayed alongside AI tool options
+- **AND** the option includes a brief description: "Automated Spectr validation on push/PR"
+- **AND** the option uses the same checkbox styling as AI tool entries
+
+#### Scenario: CI workflow option detects existing configuration
+- **WHEN** user runs `spectr init` on a project that already has `.github/workflows/spectr-ci.yml`
+- **AND** user reaches the tool selection screen
+- **THEN** the "GitHub Actions CI Workflow" option shows a "(configured)" indicator
+- **AND** the option is pre-selected by default
+- **AND** selecting it will update the existing workflow file
+
+#### Scenario: CI workflow option not pre-selected on fresh projects
+- **WHEN** user runs `spectr init` on a project without `.github/workflows/spectr-ci.yml`
+- **AND** user reaches the tool selection screen
+- **THEN** the "GitHub Actions CI Workflow" option is NOT pre-selected by default
+- **AND** the user must explicitly select it to enable CI workflow creation
+
+#### Scenario: CI workflow created when selected
+- **WHEN** user selects the "GitHub Actions CI Workflow" option
+- **AND** user confirms the selection and proceeds with initialization
+- **THEN** the system creates `.github/workflows/` directory if it doesn't exist
+- **AND** the system creates `.github/workflows/spectr-ci.yml` with the standard validation workflow
+- **AND** the workflow file is tracked in the execution result as created or updated
+
+#### Scenario: CI workflow not created when unselected
+- **WHEN** user does NOT select the "GitHub Actions CI Workflow" option
+- **AND** user confirms the selection and proceeds with initialization
+- **THEN** no `.github/workflows/spectr-ci.yml` file is created
+- **AND** any existing `.github/workflows/spectr-ci.yml` file is left unchanged
+
+#### Scenario: CI workflow content follows spec requirements
+- **WHEN** the CI workflow file is created
+- **THEN** the workflow triggers on push and pull request events
+- **AND** the workflow uses `fetch-depth: 0` for full git history
+- **AND** the workflow uses the `spectr-action` for validation
+- **AND** the workflow includes concurrency management to cancel in-progress runs
+- **AND** the workflow runs on `ubuntu-latest`
+
+#### Scenario: Review screen shows CI workflow selection
+- **WHEN** user has selected the "GitHub Actions CI Workflow" option
+- **AND** user proceeds to the review screen
+- **THEN** the review shows "GitHub Actions CI Workflow" in the list of selected items
+- **AND** the creation plan mentions the workflow file path
+
+#### Scenario: Completion screen shows CI workflow file
+- **WHEN** the CI workflow file is successfully created
+- **THEN** the completion screen lists `.github/workflows/spectr-ci.yml` in created files
+- **AND** the file path is displayed with the appropriate icon (created or updated)
+
+#### Scenario: Non-interactive mode supports CI workflow flag
+- **WHEN** user runs `spectr init --non-interactive --ci-workflow`
+- **THEN** the CI workflow file is created without TUI interaction
+- **AND** the workflow file content matches the interactive mode output

--- a/spectr/changes/add-ci-workflow-init-option/tasks.md
+++ b/spectr/changes/add-ci-workflow-init-option/tasks.md
@@ -1,0 +1,27 @@
+## 1. Template and Configuration
+
+- [ ] 1.1 Add CI workflow template to `internal/initialize/templates.go` with embedded `spectr-ci.yml` content
+- [ ] 1.2 Add `RenderCIWorkflow()` method to `TemplateManager` to generate the workflow file content
+
+## 2. Wizard TUI Updates
+
+- [ ] 2.1 Add a new checkbox option in the tool selection step for "GitHub Actions CI Workflow"
+- [ ] 2.2 Implement detection logic to check if `.github/workflows/spectr-ci.yml` already exists (mark as configured)
+- [ ] 2.3 Add descriptive text explaining what the CI workflow does when the option is highlighted
+
+## 3. Executor Integration
+
+- [ ] 3.1 Add `createCIWorkflow()` method to `InitExecutor` to create the `.github/workflows/` directory and workflow file
+- [ ] 3.2 Integrate CI workflow creation into `Execute()` flow based on selection state
+- [ ] 3.3 Track created/updated files appropriately in the execution result
+
+## 4. Testing
+
+- [ ] 4.1 Add unit tests for CI workflow template rendering
+- [ ] 4.2 Add unit tests for CI workflow file existence detection
+- [ ] 4.3 Add integration test verifying CI workflow creation during init
+
+## 5. Validation
+
+- [ ] 5.1 Run `spectr validate add-ci-workflow-init-option --strict` and fix any issues
+- [ ] 5.2 Manually test the init wizard with CI workflow option enabled and disabled


### PR DESCRIPTION
## Summary

Proposal for review: `add-ci-workflow-init-option`

**Location**: `spectr/changes/add-ci-workflow-init-option/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional GitHub Actions CI workflow setup during initialization
  * New checkbox option in the init wizard to create a Spectr CI workflow at `.github/workflows/spectr-ci.yml`
  * Support for non-interactive mode configuration of the workflow option

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->