### PR TITLE
spectr(proposal): add-ci-workflow-init-option

### DIFF
--- a/spectr/changes/add-ci-workflow-init-option/proposal.md
+++ b/spectr/changes/add-ci-workflow-init-option/proposal.md
@@ -1,0 +1,35 @@
+# Change: Add CI Workflow Setup Option to Init Wizard
+
+## Why
+Users currently need to manually set up the `.github/workflows/spectr-ci.yml` file to enable automated Spectr validation in their CI/CD pipeline. This is an extra step that many users may not know about or may forget. Adding an option in the init wizard to optionally create this workflow file provides a seamless onboarding experience and encourages best practices for CI integration.
+
+## What Changes
+- Add a "Spectr CI Validation" checkbox option to the Review step of the init wizard
+- The option appears after the tool selection summary, before the creation plan
+- When enabled, create `.github/workflows/spectr-ci.yml` with Spectr validation job only
+- The workflow uses `spectr-action@v0.0.2` and triggers on push to main and all PRs
+- Pre-select if `.github/workflows/spectr-ci.yml` already exists (treat as configured)
+- Add `--ci-workflow` flag for non-interactive mode
+
+## Design Decisions
+- **Combined with Review step**: Avoids adding another step, keeps wizard flow quick
+- **Workflow name**: `spectr-ci.yml` - dedicated Spectr workflow file that won't conflict with existing CI
+- **Workflow scope**: Spectr validation only (single `spectr-validate` job) - minimal and focused
+- **Action version**: `@v0.0.2` - pinned version for reproducibility
+- **Push triggers**: main only (PRs trigger on all branches)
+- **Label**: "Spectr CI Validation" - focuses on function rather than platform
+- **Directory handling**: Create file normally even if `.github/workflows/` already exists
+
+## Impact
+- Affected specs: `cli-interface` (MODIFIED - init wizard functionality)
+- Affected code:
+  - `internal/initialize/wizard.go` - Add CI option to Review step rendering and state
+  - `internal/initialize/executor.go` - Add CI workflow file creation logic
+  - `internal/initialize/templates.go` - Add CI workflow template
+  - `cmd/init.go` - Add `--ci-workflow` flag
+- Breaking changes: None (additive feature)
+- Benefits:
+  - Reduces onboarding friction for users who want CI validation
+  - Promotes best practices by making CI setup visible and easy
+  - No additional wizard step keeps the flow quick
+  - Maintains consistency with existing init wizard patterns

--- a/spectr/changes/add-ci-workflow-init-option/specs/cli-interface/spec.md
+++ b/spectr/changes/add-ci-workflow-init-option/specs/cli-interface/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: CI Workflow Setup Option in Init Wizard Review Step
+The initialization wizard's Review step SHALL include an optional checkbox to create a GitHub Actions workflow file (`.github/workflows/spectr-ci.yml`) for automated Spectr validation during CI/CD. This option is presented alongside the tool selection summary, keeping the wizard flow quick without adding a separate step.
+
+#### Scenario: CI option displayed in Review step
+- **WHEN** user completes tool selection and proceeds to the Review step
+- **THEN** a "Spectr CI Validation" checkbox option is displayed after the tool summary
+- **AND** the option appears before the creation plan section
+- **AND** a description explains: "Validate specs automatically on push and pull requests"
+
+#### Scenario: CI option detects existing workflow
+- **WHEN** user runs `spectr init` on a project that already has `.github/workflows/spectr-ci.yml`
+- **AND** user reaches the Review step
+- **THEN** the "Spectr CI Validation" option shows a "(configured)" indicator
+- **AND** the option is pre-selected by default
+- **AND** selecting it will update the existing workflow file
+
+#### Scenario: CI option not pre-selected on fresh projects
+- **WHEN** user runs `spectr init` on a project without `.github/workflows/spectr-ci.yml`
+- **AND** user reaches the Review step
+- **THEN** the "Spectr CI Validation" option is NOT pre-selected by default
+- **AND** the user must explicitly select it to enable CI workflow creation
+
+#### Scenario: User toggles CI option in Review step
+- **WHEN** user is on the Review step
+- **AND** user presses Space
+- **THEN** the CI workflow checkbox toggles between selected and unselected
+- **AND** the creation plan updates to reflect the change
+- **AND** the visual state updates immediately
+
+#### Scenario: CI workflow created when selected
+- **WHEN** user selects the "Spectr CI Validation" option in Review
+- **AND** user presses Enter to proceed with initialization
+- **THEN** the system creates `.github/workflows/` directory if it doesn't exist
+- **AND** the system creates `.github/workflows/spectr-ci.yml` with the Spectr validation workflow
+- **AND** the workflow file is tracked in the execution result as created or updated
+
+#### Scenario: CI workflow not created when unselected
+- **WHEN** user does NOT select the "Spectr CI Validation" option
+- **AND** user proceeds with initialization
+- **THEN** no `.github/workflows/spectr-ci.yml` file is created
+- **AND** any existing `.github/workflows/spectr-ci.yml` file is left unchanged
+
+#### Scenario: CI workflow content uses pinned action version
+- **WHEN** the CI workflow file is created
+- **THEN** the workflow contains a single `spectr-validate` job
+- **AND** the workflow uses `connerohnesorge/spectr-action@v0.0.2` (pinned version)
+- **AND** the workflow triggers on push to `main` branch only
+- **AND** the workflow triggers on pull requests to all branches
+- **AND** the workflow uses `fetch-depth: 0` for full git history
+- **AND** the workflow includes concurrency management to cancel in-progress runs
+- **AND** the workflow runs on `ubuntu-latest`
+
+#### Scenario: Creation plan shows CI workflow when enabled
+- **WHEN** user has selected the "Spectr CI Validation" option
+- **THEN** the creation plan section shows `.github/workflows/spectr-ci.yml`
+- **AND** the file is listed with the tool configurations
+
+#### Scenario: Creation plan hides CI workflow when disabled
+- **WHEN** user has NOT selected the "Spectr CI Validation" option
+- **THEN** the creation plan does NOT mention `.github/workflows/spectr-ci.yml`
+
+#### Scenario: Completion screen shows CI workflow file
+- **WHEN** the CI workflow file is successfully created
+- **THEN** the completion screen lists `.github/workflows/spectr-ci.yml` in created or updated files
+- **AND** the file path is displayed with the appropriate icon
+
+#### Scenario: Non-interactive mode supports CI workflow flag
+- **WHEN** user runs `spectr init --non-interactive --ci-workflow`
+- **THEN** the CI workflow file is created without TUI interaction
+- **AND** the workflow file content matches the interactive mode output
+
+#### Scenario: Non-interactive mode without CI flag skips workflow
+- **WHEN** user runs `spectr init --non-interactive` without `--ci-workflow`
+- **THEN** no CI workflow file is created
+- **AND** existing workflow files are not modified
+
+#### Scenario: Review step help text includes Space for toggle
+- **WHEN** user is on the Review step
+- **THEN** the help text shows: "Space: Toggle CI  Enter: Initialize  Backspace: Back  q: Quit"

--- a/spectr/changes/add-ci-workflow-init-option/tasks.md
+++ b/spectr/changes/add-ci-workflow-init-option/tasks.md
@@ -1,0 +1,35 @@
+## 1. Template and Configuration
+
+- [ ] 1.1 Add CI workflow template constant to `internal/initialize/templates.go` with embedded `spectr-ci.yml` content (spectr-validate job only, using `spectr-action@v0.0.2`)
+- [ ] 1.2 Add `RenderCIWorkflow()` method to `TemplateManager` to generate the workflow file content
+
+## 2. Wizard TUI Updates
+
+- [ ] 2.1 Add `ciWorkflowEnabled` and `ciWorkflowConfigured` fields to `WizardModel`
+- [ ] 2.2 Add detection logic in `NewWizardModel` to check if `.github/workflows/spectr-ci.yml` exists (set `ciWorkflowConfigured` and pre-select if true)
+- [ ] 2.3 Update `renderReview()` to display the "Spectr CI Validation" checkbox option after tool summary
+- [ ] 2.4 Update `handleReviewKeys()` to support Space key for toggling CI option (in addition to Enter/Backspace)
+- [ ] 2.5 Update `renderCreationPlan()` to conditionally show `.github/workflows/spectr-ci.yml` when CI is enabled
+
+## 3. Executor Integration
+
+- [ ] 3.1 Add `createCIWorkflow()` method to `InitExecutor` to create the `.github/workflows/` directory and `spectr-ci.yml` file
+- [ ] 3.2 Update `Execute()` signature to accept CI workflow enablement flag
+- [ ] 3.3 Call `createCIWorkflow()` when CI workflow is enabled, track created/updated files in result
+
+## 4. Non-Interactive Mode
+
+- [ ] 4.1 Add `CIWorkflow bool` field with `--ci-workflow` flag to `InitCmd` in `cmd/init.go`
+- [ ] 4.2 Pass `--ci-workflow` flag value to executor in non-interactive mode
+
+## 5. Testing
+
+- [ ] 5.1 Add unit tests for CI workflow template rendering
+- [ ] 5.2 Add unit tests for CI workflow file existence detection
+- [ ] 5.3 Add unit tests for Review step with CI option toggling
+
+## 6. Validation
+
+- [ ] 6.1 Run `spectr validate add-ci-workflow-init-option --strict` and fix any issues
+- [ ] 6.2 Manually test the init wizard flow with CI option enabled and disabled
+- [ ] 6.3 Test non-interactive mode with and without `--ci-workflow` flag


### PR DESCRIPTION
## Summary

Proposal for review: `add-ci-workflow-init-option`

**Location**: `spectr/changes/add-ci-workflow-init-option/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CI workflow configuration during initialization wizard setup.
  * Automatically generates a CI workflow file with Spectr validation job.
  * New `--ci-workflow` command-line flag enables non-interactive CI workflow setup.
  * Intelligently detects existing workflows and pre-selects the configuration option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->