### PR TITLE
spectr(proposal): add-tasks-json-acceptance

### DIFF
--- a/spectr/changes/add-tasks-json-acceptance/proposal.md
+++ b/spectr/changes/add-tasks-json-acceptance/proposal.md
@@ -1,28 +1,31 @@
-# Change: Add `spectr accept` command for tasks.md to tasks.json conversion
+# Change: Add Tasks JSON Acceptance Command
 
 ## Why
 
-Inspired by Anthropic's research on [long-running agents](https://www.anthropic.com/research/effective-harnesses-for-long-running-agents), task lists in JSON format are significantly more stable for AI agents than Markdown. Agents are less likely to accidentally modify or overwrite structured JSON files compared to Markdown. This change introduces a `spectr accept` command that converts human-readable `tasks.md` to machine-stable `tasks.json` when a proposal is approved, then removes the original `tasks.md` to prevent drift. The `apply` slash command will require calling `spectr accept` first before implementation begins.
+Inspired by Anthropic's research on [long-running agents](https://www.anthropic.com/research/effective-harnesses-for-long-running-agents), task lists in JSON format are significantly more stable for AI agents than Markdown. Agents are less likely to accidentally modify or overwrite structured JSON files compared to Markdown. This is because:
+
+1. **Structural validation**: JSON parsers will immediately fail if the format is corrupted, whereas Markdown changes can silently corrupt task lists
+2. **Atomic field updates**: Agents can update a single `status` field in JSON without risk of rewriting the entire task description
+3. **Machine readability**: JSON provides unambiguous field boundaries, eliminating regex-based parsing that can fail on edge cases
+4. **Drift prevention**: Once `tasks.md` is converted to `tasks.json`, the original is removed, ensuring a single source of truth
 
 ## What Changes
 
-- **Add `spectr accept <change-id>` CLI command** - Converts tasks.md to tasks.json format
-- **Define tasks.json schema** - Structured JSON format preserving sections, task IDs, descriptions, and completion status
-- **Add task parser** - Parse tasks.md format into structured Task objects
-  - Support unlimited recursive nesting (1.1.1.1...)
-  - Append indented detail lines to task descriptions
-  - Preserve existing `[x]` completion status
-- **Remove tasks.md after conversion** - Delete original file to prevent drift between formats
-- **Update apply slash command** - Instruct agent to run `spectr accept` if tasks.json missing
-- **Archive existing tasks.md files** - Provide testdata fixtures from rich archive
+- Add a new `spectr accept <change-id>` command that converts `tasks.md` to `tasks.json` format
+- The `accept` command validates the change before conversion (using existing validation)
+- After successful conversion, `tasks.md` is removed to prevent drift between formats
+- The `apply` slash command is updated to require agents to run `spectr accept` first before implementation begins
+- All internal tooling (`parsers.CountTasks`, `view`, `list`, etc.) is updated to read from `tasks.json` when present, falling back to `tasks.md` for backward compatibility
 
 ## Impact
 
 - Affected specs: `cli-framework`, `archive-workflow`
 - Affected code:
-  - `cmd/root.go` (new AcceptCmd)
-  - `internal/accept/` (new package)
-  - `internal/parsers/parsers.go` (enhanced task parsing)
-  - `.claude/commands/spectr/apply.md` (updated workflow)
-- Testdata: Use archived tasks.md files as test fixtures
-- **Non-breaking**: tasks.md remains valid for proposal phase; conversion happens at acceptance
+  - `cmd/accept.go` (new)
+  - `cmd/root.go` (add AcceptCmd)
+  - `internal/parsers/parsers.go` (update CountTasks for JSON support)
+  - `internal/archive/archiver.go` (update task counting)
+  - `internal/list/lister.go` (update task counting)
+  - `internal/view/dashboard.go` (update task counting)
+  - `.claude/commands/spectr/apply.md` (add accept step)
+  - Template files for slash commands

--- a/spectr/changes/add-tasks-json-acceptance/specs/cli-framework/spec.md
+++ b/spectr/changes/add-tasks-json-acceptance/specs/cli-framework/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Accept Command Structure
-The CLI SHALL provide an `accept` command that converts tasks.md to tasks.json format when a change proposal is approved for implementation.
+The CLI SHALL provide an `accept` command that converts `tasks.md` to `tasks.json` format for stable agent manipulation during implementation.
 
 #### Scenario: Accept command registration
 - **WHEN** the CLI is initialized
@@ -11,133 +11,88 @@ The CLI SHALL provide an `accept` command that converts tasks.md to tasks.json f
 
 #### Scenario: Accept with change ID
 - **WHEN** user runs `spectr accept <change-id>`
-- **THEN** the system converts tasks.md to tasks.json for the specified change
-- **AND** removes the original tasks.md file
-- **AND** displays a success message with the generated file path
+- **THEN** the system validates the change exists in `spectr/changes/<change-id>/`
+- **AND** the system parses `tasks.md` into structured format
+- **AND** the system writes `tasks.json` with proper schema
+- **AND** the system removes `tasks.md` to prevent drift
 
-#### Scenario: Interactive accept selection
-- **WHEN** user runs `spectr accept` without specifying a change ID
-- **THEN** the system displays a list of active changes with tasks.md files
-- **AND** prompts for selection
+#### Scenario: Accept with validation
+- **WHEN** user runs `spectr accept <change-id>`
+- **THEN** the system validates the change before conversion
+- **AND** the system blocks acceptance if validation fails
+- **AND** the system displays validation errors
 
-#### Scenario: Non-interactive accept with yes flag
-- **WHEN** user runs `spectr accept <change-id> --yes`
-- **THEN** the system converts without any confirmation prompts
+#### Scenario: Accept dry-run mode
+- **WHEN** user runs `spectr accept <change-id> --dry-run`
+- **THEN** the system displays what would be converted
+- **AND** the system does NOT write tasks.json
+- **AND** the system does NOT remove tasks.md
+
+#### Scenario: Accept already accepted change
+- **WHEN** user runs `spectr accept <change-id>` on a change that already has tasks.json
+- **THEN** the system displays a message indicating change is already accepted
+- **AND** the system exits with code 0 (success, idempotent)
+
+#### Scenario: Accept change without tasks.md
+- **WHEN** user runs `spectr accept <change-id>` on a change without tasks.md
+- **THEN** the system displays an error indicating no tasks.md found
+- **AND** the system exits with code 1
+
+### Requirement: Tasks JSON Schema
+The accept command SHALL generate `tasks.json` files conforming to a versioned schema with structured task objects.
+
+#### Scenario: JSON file structure
+- **WHEN** the accept command creates tasks.json
+- **THEN** the file SHALL contain a root object with `version` and `tasks` fields
+- **AND** `version` SHALL be integer 1 for this schema version
+- **AND** `tasks` SHALL be an array of task objects
+
+#### Scenario: Task object structure
+- **WHEN** a task is serialized to JSON
+- **THEN** it SHALL have `id` field containing the task identifier (e.g., "1.1")
+- **AND** it SHALL have `section` field containing the section header (e.g., "Implementation")
+- **AND** it SHALL have `description` field containing the full task text
+- **AND** it SHALL have `status` field with value "pending", "in_progress", or "completed"
+
+#### Scenario: Status value mapping from Markdown
+- **WHEN** converting tasks.md to tasks.json
+- **THEN** `- [ ]` SHALL map to status "pending"
+- **AND** `- [x]` (case-insensitive) SHALL map to status "completed"
 
 ### Requirement: Accept Command Flags
 The accept command SHALL support flags for controlling behavior.
 
-#### Scenario: Yes flag skips confirmation
-- **WHEN** user provides the `-y` or `--yes` flag
-- **THEN** the system skips the confirmation prompt before conversion
+#### Scenario: Dry-run flag
+- **WHEN** user provides the `--dry-run` flag
+- **THEN** the system previews the conversion without writing files
+- **AND** displays the JSON that would be generated
 
-### Requirement: Accept Command Validation
-The accept command SHALL validate preconditions before conversion.
+#### Scenario: Interactive change selection
+- **WHEN** user runs `spectr accept` without specifying a change ID
+- **THEN** the system displays a list of active changes with tasks.md files
+- **AND** prompts for selection using existing TUI components
 
-#### Scenario: Change must exist
-- **WHEN** user runs `spectr accept <change-id>` for a non-existent change
-- **THEN** the system displays an error message and exits with non-zero code
+## MODIFIED Requirements
 
-#### Scenario: tasks.md must exist
-- **WHEN** user runs `spectr accept <change-id>` and tasks.md does not exist
-- **THEN** the system displays an error: "No tasks.md found for change '<change-id>'"
+### Requirement: Task Counting
+The system SHALL count tasks in `tasks.md` files by identifying lines matching the pattern `- [ ]` or `- [x]` (case-insensitive), with completed tasks marked by `[x]`. The system SHALL prefer `tasks.json` when present.
 
-#### Scenario: tasks.json must not already exist
-- **WHEN** user runs `spectr accept <change-id>` and tasks.json already exists
-- **THEN** the system displays an error: "Change '<change-id>' has already been accepted"
+#### Scenario: Count tasks from JSON
+- **WHEN** the system counts tasks and `tasks.json` exists
+- **THEN** it reads task status from the JSON file
+- **AND** counts tasks by status field values
+- **AND** reports `taskStatus` with total and completed counts
 
-### Requirement: tasks.json Schema
-The accept command SHALL generate tasks.json with a structured schema that preserves task hierarchy and metadata.
+#### Scenario: Count completed and total tasks
+- **WHEN** the system reads a `tasks.md` file with 3 tasks, 2 marked `[x]` and 1 marked `[ ]`
+- **THEN** it reports `taskStatus` as `{ total: 3, completed: 2 }`
 
-#### Scenario: JSON structure fields
-- **WHEN** tasks.json is generated
-- **THEN** it SHALL include `version` field with value "1.0"
-- **AND** it SHALL include `changeId` field with the change identifier
-- **AND** it SHALL include `acceptedAt` field with ISO 8601 timestamp
-- **AND** it SHALL include `sections` array with section objects
-- **AND** it SHALL include `summary` object with total and completed counts
+#### Scenario: Handle missing tasks file
+- **WHEN** the system cannot find or read a `tasks.md` or `tasks.json` file for a change
+- **THEN** it reports `taskStatus` as `{ total: 0, completed: 0 }`
+- **AND** continues processing without error
 
-#### Scenario: Section object structure
-- **WHEN** parsing a section from tasks.md
-- **THEN** each section object SHALL include `name` (section title)
-- **AND** SHALL include `number` (section number from header)
-- **AND** SHALL include `tasks` array with task objects
-
-#### Scenario: Task object structure
-- **WHEN** parsing a task from tasks.md
-- **THEN** each task object SHALL include `id` (e.g., "1.1", "2.3")
-- **AND** SHALL include `description` (task text after ID, with indented detail lines appended)
-- **AND** SHALL include `completed` boolean based on `[x]` vs `[ ]`
-- **AND** SHALL include `subtasks` array (empty if no nested tasks, recursive for unlimited depth)
-
-#### Scenario: Summary calculation
-- **WHEN** generating tasks.json
-- **THEN** summary.total SHALL equal total number of tasks across all sections (including all nested subtasks recursively)
-- **AND** summary.completed SHALL equal number of tasks with `completed: true` (including nested subtasks)
-
-### Requirement: Task ID Parsing
-The accept command SHALL parse task IDs from the standard tasks.md format.
-
-#### Scenario: Parse simple task ID
-- **WHEN** parsing line `- [ ] 1.1 Create database schema`
-- **THEN** task ID SHALL be "1.1"
-- **AND** description SHALL be "Create database schema"
-- **AND** completed SHALL be false
-
-#### Scenario: Parse completed task
-- **WHEN** parsing line `- [x] 2.3 Write unit tests`
-- **THEN** task ID SHALL be "2.3"
-- **AND** completed SHALL be true
-
-#### Scenario: Parse nested subtask
-- **WHEN** parsing line `- [ ] 1.1.1 Create users table`
-- **THEN** task ID SHALL be "1.1.1"
-- **AND** the task SHALL be added to subtasks of task "1.1"
-
-#### Scenario: Parse deeply nested subtask
-- **WHEN** parsing line `- [ ] 1.1.1.1 Add primary key constraint`
-- **THEN** task ID SHALL be "1.1.1.1"
-- **AND** the task SHALL be added to subtasks of task "1.1.1" (unlimited nesting depth)
-
-#### Scenario: Handle task without ID
-- **WHEN** parsing line `- [ ] Some task without numeric ID`
-- **THEN** the system SHALL generate an auto-incremented ID within its section
-- **AND** description SHALL be "Some task without numeric ID"
-
-#### Scenario: Parse task with indented detail lines
-- **WHEN** parsing a task followed by indented lines (2+ spaces or tab):
-  ```
-  - [ ] 1.1 Create database schema
-    - Parse requirement headers
-    - Extract requirement name and content
-  ```
-- **THEN** the indented lines SHALL be appended to the description with newlines
-- **AND** the final description SHALL be "Create database schema\n- Parse requirement headers\n- Extract requirement name and content"
-
-#### Scenario: Preserve completion status from tasks.md
-- **WHEN** parsing a task marked `[x]` in tasks.md
-- **THEN** the task SHALL have `completed: true` in tasks.json
-- **AND** existing progress is preserved during acceptance
-
-### Requirement: Section Header Parsing
-The accept command SHALL parse section headers from tasks.md format.
-
-#### Scenario: Parse numbered section header
-- **WHEN** parsing line `## 1. Implementation`
-- **THEN** section number SHALL be 1
-- **AND** section name SHALL be "Implementation"
-
-#### Scenario: Parse section header without number
-- **WHEN** parsing line `## Validation`
-- **THEN** section number SHALL be auto-assigned based on order
-- **AND** section name SHALL be "Validation"
-
-### Requirement: Accept Command Help Text
-The accept command SHALL provide comprehensive help documentation.
-
-#### Scenario: Command help display
-- **WHEN** user invokes `spectr accept --help`
-- **THEN** help text SHALL describe task conversion purpose
-- **AND** SHALL explain that tasks.md is converted to tasks.json
-- **AND** SHALL note that tasks.md is removed after conversion
-- **AND** SHALL list available flags with descriptions
+#### Scenario: JSON takes precedence over Markdown
+- **WHEN** both `tasks.json` and `tasks.md` exist (should not happen normally)
+- **THEN** the system reads from `tasks.json`
+- **AND** ignores `tasks.md`

--- a/spectr/changes/add-tasks-json-acceptance/tasks.md
+++ b/spectr/changes/add-tasks-json-acceptance/tasks.md
@@ -1,81 +1,53 @@
-## 1. Task Parser Implementation
+## 1. Core Accept Command
 
-- [ ] 1.1 Create `internal/accept/types.go` with Task, Section, and TasksJSON struct definitions
-- [ ] 1.2 Create `internal/accept/parser.go` to parse tasks.md into structured format
-  - Parse section headers (`## N. Section Name`)
-  - Parse task lines (`- [ ] N.N Description`)
-  - Handle unlimited nested subtasks recursively (`- [ ] N.N.N.N...`)
-  - Parse indented detail lines and append to task description
-  - Preserve completion status from `[x]` markers
-- [ ] 1.3 Add comprehensive tests in `internal/accept/parser_test.go`
-  - Test section parsing
-  - Test task ID extraction
-  - Test completion status detection (preserve [x] markers)
-  - Test unlimited recursive nesting (1.1.1.1.1...)
-  - Test indented detail line parsing and description concatenation
-  - Test edge cases (empty sections, no tasks, malformed lines)
+- [ ] 1.1 Create `cmd/accept.go` with `AcceptCmd` struct following Kong patterns
+- [ ] 1.2 Add `AcceptCmd` to `CLI` struct in `cmd/root.go`
+- [ ] 1.3 Implement `Run()` method that validates change exists
+- [ ] 1.4 Implement `parseTasksMd()` function to parse tasks.md into structured format
+- [ ] 1.5 Implement `writeTasksJson()` function to write tasks.json with proper schema
+- [ ] 1.6 Add change validation step before conversion (reuse existing validation)
+- [ ] 1.7 Remove tasks.md after successful tasks.json creation
+- [ ] 1.8 Add `--dry-run` flag to preview conversion without writing files
 
-## 2. Test Fixtures from Archive
+## 2. JSON Schema and Types
 
-- [ ] 2.1 Identify diverse tasks.md examples from `spectr/changes/archive/`
-- [ ] 2.2 Copy selected fixtures to `testdata/tasks/` directory
-  - Include simple, medium, and complex examples
-  - Include examples with nested tasks
-  - Include examples with all tasks completed
-- [ ] 2.3 Create expected JSON outputs for each fixture
+- [ ] 2.1 Define `TasksFile` struct with version field and tasks array
+- [ ] 2.2 Define `Task` struct with id, section, description, and status fields
+- [ ] 2.3 Add JSON struct tags for proper serialization
+- [ ] 2.4 Add `TaskStatus` type with `pending`, `in_progress`, `completed` values
 
-## 3. JSON Schema Implementation
+## 3. Parser Updates
 
-- [ ] 3.1 Define tasks.json schema with version, metadata, sections, and summary
-- [ ] 3.2 Create `internal/accept/writer.go` for JSON generation
-  - Atomic write with temp file rename
-  - Pretty-print with 2-space indentation
-  - Calculate summary totals automatically
-- [ ] 3.3 Add writer tests with golden file comparison
+- [ ] 3.1 Update `parsers.CountTasks()` to check for `tasks.json` first
+- [ ] 3.2 Add `parsers.ReadTasksJson()` function to read and parse tasks.json
+- [ ] 3.3 Ensure backward compatibility - fall back to tasks.md if no JSON exists
+- [ ] 3.4 Update `parsers.TaskStatus` to include in_progress count if needed
 
-## 4. Accept Command Implementation
+## 4. Integration with Existing Commands
 
-- [ ] 4.1 Create `cmd/accept.go` with AcceptCmd struct
-  - ChangeID positional argument (optional for interactive selection)
-  - `--yes` flag to skip confirmation prompt
-- [ ] 4.2 Add AcceptCmd to CLI struct in `cmd/root.go`
-- [ ] 4.3 Create `internal/accept/accept.go` with core workflow
-  - Validate change exists
-  - Check tasks.md exists
-  - Check tasks.json does not already exist
-  - Parse tasks.md
-  - Generate tasks.json
-  - Remove tasks.md
-- [ ] 4.4 Add confirmation prompt before conversion (unless --yes)
-- [ ] 4.5 Add success/error output messages
+- [ ] 4.1 Update `internal/archive/archiver.go` to use new task reading logic
+- [ ] 4.2 Update `internal/list/lister.go` to use new task reading logic
+- [ ] 4.3 Update `internal/view/dashboard.go` to use new task reading logic
+- [ ] 4.4 Add auto-accept step to archive command when tasks.md still exists (with warning)
 
-## 5. Apply Slash Command Integration
+## 5. Slash Command Updates
 
-- [ ] 5.1 Update `.claude/commands/spectr/apply.md` to integrate acceptance workflow
-  - Check if tasks.json exists for the change
-  - If missing, instruct agent: "Run `spectr accept <change-id>` first"
-  - Update task tracking instructions to use tasks.json instead of tasks.md
-  - Clarify that tasks.json is the source of truth after acceptance
-- [ ] 5.2 Document the acceptance workflow in AGENTS.md reference
+- [ ] 5.1 Update `.claude/commands/spectr/apply.md` to require `spectr accept` first
+- [ ] 5.2 Update `.gemini/commands/spectr/apply.toml` with accept requirement
+- [ ] 5.3 Update template files in `internal/initialize/templates/tools/slash-apply.md.tmpl`
+- [ ] 5.4 Add `spectr accept` instructions to AGENTS.md Stage 2 workflow
 
-## 6. Archive Workflow Compatibility
+## 6. Testing
 
-- [ ] 6.1 Update `internal/archive/archiver.go` checkTasks() to handle both formats
-  - Check for tasks.json first, fall back to tasks.md
-  - Parse tasks.json for completion status
-- [ ] 6.2 Add JSON task parser to `internal/parsers/parsers.go`
-  - CountTasksJSON() function
-- [ ] 6.3 Update `internal/list/` and `internal/view/` to support tasks.json
+- [ ] 6.1 Add unit tests for `parseTasksMd()` with various task formats
+- [ ] 6.2 Add unit tests for `writeTasksJson()` with expected output
+- [ ] 6.3 Add unit tests for `parsers.ReadTasksJson()`
+- [ ] 6.4 Add integration test for full accept workflow
+- [ ] 6.5 Add test for backward compatibility (tasks.md fallback)
+- [ ] 6.6 Add test for dry-run mode
 
-## 7. Validation
+## 7. Documentation
 
-- [ ] 7.1 Run `go build` to verify compilation
-- [ ] 7.2 Run `go test ./...` to verify all tests pass
-- [ ] 7.3 Run `golangci-lint run` to verify no linting errors
-- [ ] 7.4 Test `spectr accept` command manually with a test change
-- [ ] 7.5 Run `spectr validate add-tasks-json-acceptance --strict`
-
-## 8. Documentation
-
-- [ ] 8.1 Add help text to accept command describing purpose and workflow
-- [ ] 8.2 Update CLI help to show accept command
+- [ ] 7.1 Update README with `spectr accept` command documentation
+- [ ] 7.2 Update CLI reference docs with accept command
+- [ ] 7.3 Add example tasks.json format to documentation


### PR DESCRIPTION
## Summary

Proposal for review: `add-tasks-json-acceptance`

**Location**: `spectr/changes/add-tasks-json-acceptance/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `spectr accept <change-id>` command to convert task state from markdown to JSON format.
  * Introduced auto-accept functionality during archive operations with user warnings to prevent manual steps.
  * Added dry-run preview mode for task conversions.
  * Expanded task status tracking with new in-progress state (pending, in-progress, completed).

* **Improvements**
  * Task reading now prioritizes JSON format with automatic fallback to markdown for backward compatibility.
  * Enhanced task workflow with explicit acceptance gate before implementation begins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->