### PR TITLE
feat: add CI workflow option to init command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -104,7 +104,7 @@ func runNonInteractiveInit(c *InitCmd) error {
 		return fmt.Errorf("failed to create executor: %w", err)
 	}
 
-	result, err := executor.Execute(selectedProviders)
+	result, err := executor.Execute(selectedProviders, c.CIWorkflow)
 	if err != nil {
 		return fmt.Errorf("initialization failed: %w", err)
 	}

--- a/internal/initialize/models.go
+++ b/internal/initialize/models.go
@@ -6,6 +6,7 @@ type InitCmd struct {
 	PathFlag       string   `name:"path" short:"p" help:"Alt project path"`
 	Tools          []string `name:"tools" short:"t" help:"Tools list"`
 	NonInteractive bool     `name:"non-interactive" help:"Non-interactive"`
+	CIWorkflow     bool     `name:"ci-workflow" help:"Create CI workflow file"`
 }
 
 // ProjectConfig holds the overall project configuration during init

--- a/internal/initialize/templates.go
+++ b/internal/initialize/templates.go
@@ -100,3 +100,15 @@ func (tm *TemplateManager) RenderSlashCommand(
 
 	return buf.String(), nil
 }
+
+// RenderCIWorkflow renders the spectr-ci.yml template for GitHub Actions
+// This template has no variables and returns the CI workflow configuration
+func (tm *TemplateManager) RenderCIWorkflow() (string, error) {
+	var buf bytes.Buffer
+	err := tm.templates.ExecuteTemplate(&buf, "spectr-ci.yml.tmpl", nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to render CI workflow template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/internal/initialize/templates/ci/spectr-ci.yml.tmpl
+++ b/internal/initialize/templates/ci/spectr-ci.yml.tmpl
@@ -1,0 +1,16 @@
+name: Spectr Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  spectr-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: connerohnesorge/spectr-action@v0.0.2
+        with:
+          strict: false

--- a/internal/initialize/templates_test.go
+++ b/internal/initialize/templates_test.go
@@ -276,6 +276,37 @@ func TestTemplateManager_RenderSlashCommand(t *testing.T) {
 	}
 }
 
+func TestTemplateManager_RenderCIWorkflow(t *testing.T) {
+	tm, err := NewTemplateManager()
+	if err != nil {
+		t.Fatalf("NewTemplateManager() error = %v", err)
+	}
+
+	got, err := tm.RenderCIWorkflow()
+	if err != nil {
+		t.Fatalf("RenderCIWorkflow() error = %v", err)
+	}
+
+	// Check for key content in CI workflow
+	expectedContent := []string{
+		"name: Spectr Validation",
+		"push:",
+		"pull_request:",
+		"branches: [main]",
+		"spectr-validate:",
+		"runs-on: ubuntu-latest",
+		"actions/checkout@v4",
+		"connerohnesorge/spectr-action@v0.0.2",
+		"strict: false",
+	}
+
+	for _, content := range expectedContent {
+		if !strings.Contains(got, content) {
+			t.Errorf("RenderCIWorkflow() missing expected content %q", content)
+		}
+	}
+}
+
 func TestTemplateManager_AllTemplatesCompile(t *testing.T) {
 	tm, err := NewTemplateManager()
 	if err != nil {
@@ -316,6 +347,13 @@ func TestTemplateManager_AllTemplatesCompile(t *testing.T) {
 			if err != nil {
 				t.Errorf("Slash command %s failed to render: %v", cmd, err)
 			}
+		}
+	})
+
+	t.Run("ci workflow template", func(t *testing.T) {
+		_, err := tm.RenderCIWorkflow()
+		if err != nil {
+			t.Errorf("CI workflow template failed to render: %v", err)
 		}
 	})
 }

--- a/spectr/changes/add-ci-workflow-init-option/tasks.md
+++ b/spectr/changes/add-ci-workflow-init-option/tasks.md
@@ -1,35 +1,35 @@
 ## 1. Template and Configuration
 
-- [ ] 1.1 Add CI workflow template constant to `internal/initialize/templates.go` with embedded `spectr-ci.yml` content (spectr-validate job only, using `spectr-action@v0.0.2`)
-- [ ] 1.2 Add `RenderCIWorkflow()` method to `TemplateManager` to generate the workflow file content
+- [x] 1.1 Add CI workflow template constant to `internal/initialize/templates.go` with embedded `spectr-ci.yml` content (spectr-validate job only, using `spectr-action@v0.0.2`)
+- [x] 1.2 Add `RenderCIWorkflow()` method to `TemplateManager` to generate the workflow file content
 
 ## 2. Wizard TUI Updates
 
-- [ ] 2.1 Add `ciWorkflowEnabled` and `ciWorkflowConfigured` fields to `WizardModel`
-- [ ] 2.2 Add detection logic in `NewWizardModel` to check if `.github/workflows/spectr-ci.yml` exists (set `ciWorkflowConfigured` and pre-select if true)
-- [ ] 2.3 Update `renderReview()` to display the "Spectr CI Validation" checkbox option after tool summary
-- [ ] 2.4 Update `handleReviewKeys()` to support Space key for toggling CI option (in addition to Enter/Backspace)
-- [ ] 2.5 Update `renderCreationPlan()` to conditionally show `.github/workflows/spectr-ci.yml` when CI is enabled
+- [x] 2.1 Add `ciWorkflowEnabled` and `ciWorkflowConfigured` fields to `WizardModel`
+- [x] 2.2 Add detection logic in `NewWizardModel` to check if `.github/workflows/spectr-ci.yml` exists (set `ciWorkflowConfigured` and pre-select if true)
+- [x] 2.3 Update `renderReview()` to display the "Spectr CI Validation" checkbox option after tool summary
+- [x] 2.4 Update `handleReviewKeys()` to support Space key for toggling CI option (in addition to Enter/Backspace)
+- [x] 2.5 Update `renderCreationPlan()` to conditionally show `.github/workflows/spectr-ci.yml` when CI is enabled
 
 ## 3. Executor Integration
 
-- [ ] 3.1 Add `createCIWorkflow()` method to `InitExecutor` to create the `.github/workflows/` directory and `spectr-ci.yml` file
-- [ ] 3.2 Update `Execute()` signature to accept CI workflow enablement flag
-- [ ] 3.3 Call `createCIWorkflow()` when CI workflow is enabled, track created/updated files in result
+- [x] 3.1 Add `createCIWorkflow()` method to `InitExecutor` to create the `.github/workflows/` directory and `spectr-ci.yml` file
+- [x] 3.2 Update `Execute()` signature to accept CI workflow enablement flag
+- [x] 3.3 Call `createCIWorkflow()` when CI workflow is enabled, track created/updated files in result
 
 ## 4. Non-Interactive Mode
 
-- [ ] 4.1 Add `CIWorkflow bool` field with `--ci-workflow` flag to `InitCmd` in `cmd/init.go`
-- [ ] 4.2 Pass `--ci-workflow` flag value to executor in non-interactive mode
+- [x] 4.1 Add `CIWorkflow bool` field with `--ci-workflow` flag to `InitCmd` in `cmd/init.go`
+- [x] 4.2 Pass `--ci-workflow` flag value to executor in non-interactive mode
 
 ## 5. Testing
 
-- [ ] 5.1 Add unit tests for CI workflow template rendering
-- [ ] 5.2 Add unit tests for CI workflow file existence detection
-- [ ] 5.3 Add unit tests for Review step with CI option toggling
+- [x] 5.1 Add unit tests for CI workflow template rendering
+- [x] 5.2 Add unit tests for CI workflow file existence detection
+- [x] 5.3 Add unit tests for Review step with CI option toggling
 
 ## 6. Validation
 
-- [ ] 6.1 Run `spectr validate add-ci-workflow-init-option --strict` and fix any issues
-- [ ] 6.2 Manually test the init wizard flow with CI option enabled and disabled
-- [ ] 6.3 Test non-interactive mode with and without `--ci-workflow` flag
+- [x] 6.1 Run `spectr validate add-ci-workflow-init-option --strict` and fix any issues
+- [x] 6.2 Manually test the init wizard flow with CI option enabled and disabled
+- [x] 6.3 Test non-interactive mode with and without `--ci-workflow` flag


### PR DESCRIPTION
Implements the ability to optionally create a GitHub Actions CI workflow during project initialization. Users can enable this in the interactive wizard or via the --ci-workflow flag in non-interactive mode.

Changes:
- Add CIWorkflow flag to InitCmd for non-interactive mode
- Create RenderCIWorkflow() template method for spectr-ci.yml
- Add createCIWorkflow() method to InitExecutor
- Update Execute() to accept CI workflow enablement flag
- Extend WizardModel to detect and manage CI workflow option
- Add UI support in wizard Review step for toggling CI option
- Add comprehensive unit tests for CI workflow functionality
- Update task checklist with completed items

The CI workflow template includes a spectr-validate job that runs validation checks using the spectr-action@v0.0.2 GitHub Action.