### PR TITLE
spectr(proposal): add-list-alias

### DIFF
--- a/spectr/changes/add-list-alias/proposal.md
+++ b/spectr/changes/add-list-alias/proposal.md
@@ -1,0 +1,20 @@
+# Change: Add `ls` alias for `spectr list` command
+
+## Why
+
+Users familiar with Unix command-line conventions often expect `ls` to list items. Providing a shorthand `spectr ls` reduces typing and improves CLI ergonomics, consistent with the existing pattern where PR subcommands have single-letter aliases (e.g., `spectr pr a` for `spectr pr archive`).
+
+## What Changes
+
+- Add `ls` as an alias for the `list` command
+- Users can invoke `spectr ls` as equivalent to `spectr list`
+- All existing flags (`--specs`, `--all`, `--long`, `--json`, `--interactive`) work with the alias
+
+## Dependencies
+
+None.
+
+## Impact
+
+- Affected specs: `cli-framework`
+- Affected code: `cmd/root.go` (single line change to add `aliases:"ls"` tag)

--- a/spectr/changes/add-list-alias/specs/cli-framework/spec.md
+++ b/spectr/changes/add-list-alias/specs/cli-framework/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: List Command Alias
+
+The `spectr list` command SHALL support `ls` as a shorthand alias, allowing users to invoke `spectr ls` as equivalent to `spectr list`.
+
+#### Scenario: User runs spectr ls shorthand
+
+- **WHEN** user runs `spectr ls`
+- **THEN** the system displays the list of changes identically to `spectr list`
+- **AND** all flags (`--specs`, `--all`, `--long`, `--json`, `--interactive`) work with the alias
+
+#### Scenario: User runs spectr ls with flags
+
+- **WHEN** user runs `spectr ls --specs --long`
+- **THEN** the command behaves identically to `spectr list --specs --long`
+- **AND** specs are displayed in long format
+
+#### Scenario: Help text shows list alias
+
+- **WHEN** user runs `spectr --help`
+- **THEN** the help text displays `list` with its `ls` alias
+- **AND** the alias is shown in parentheses or as comma-separated alternatives

--- a/spectr/changes/add-list-alias/tasks.md
+++ b/spectr/changes/add-list-alias/tasks.md
@@ -1,0 +1,5 @@
+## 1. Implementation
+
+- [ ] 1.1 Add `aliases:"ls"` tag to `ListCmd` struct in `cmd/root.go`
+- [ ] 1.2 Add test case verifying `spectr ls` works identically to `spectr list`
+- [ ] 1.3 Verify help text shows alias in command listing


### PR DESCRIPTION
## Summary

Proposal for review: `add-list-alias`

**Location**: `spectr/changes/add-list-alias/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "ls" as an official alias for the "list" command. Users can now execute `spectr ls` as an alternative to `spectr list`. All existing flags (--specs, --all, --long, --json, --interactive) are fully supported with identical functionality and updated help documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->