### PR TITLE
feat: add `ls` alias for `spectr list` command

### DIFF
--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -42,3 +42,24 @@ func TestCLIHasListCommand(t *testing.T) {
 		t.Errorf("List field type: got %s, want ListCmd", listField.Type().Name())
 	}
 }
+
+// TestListCmd_HasLsAlias verifies that the list command has the "ls" alias.
+// This ensures "spectr ls" works identically to "spectr list".
+func TestListCmd_HasLsAlias(t *testing.T) {
+	cliType := reflect.TypeOf(CLI{})
+	listField, found := cliType.FieldByName("List")
+	if !found {
+		t.Fatal("CLI does not have List field")
+	}
+
+	// Get the aliases tag
+	tag := listField.Tag
+	aliases := tag.Get("aliases")
+	if aliases == "" {
+		t.Fatal("List field does not have aliases tag")
+	}
+
+	if aliases != "ls" {
+		t.Errorf("List aliases = %q, want %q", aliases, "ls")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 // CLI represents the root command structure for Kong
 type CLI struct {
 	Init       InitCmd                   `cmd:"" help:"Initialize Spectr"`
-	List       ListCmd                   `cmd:"" help:"List changes or specs"`
+	List       ListCmd                   `cmd:"" aliases:"ls" help:"List items"`
 	Validate   ValidateCmd               `cmd:"" help:"Validate items"`
 	Accept     AcceptCmd                 `cmd:"" help:"Accept tasks.md"`
 	Archive    archive.ArchiveCmd        `cmd:"" help:"Archive a change"`

--- a/spectr/changes/add-list-alias/tasks.json
+++ b/spectr/changes/add-list-alias/tasks.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "tasks": [
+    {
+      "id": "1.1",
+      "section": "Implementation",
+      "description": "Add `aliases:\"ls\"` tag to `ListCmd` struct in `cmd/root.go`",
+      "status": "completed"
+    },
+    {
+      "id": "1.2",
+      "section": "Implementation",
+      "description": "Add test case verifying `spectr ls` works identically to `spectr list`",
+      "status": "completed"
+    },
+    {
+      "id": "1.3",
+      "section": "Implementation",
+      "description": "Verify help text shows alias in command listing",
+      "status": "completed"
+    }
+  ]
+}

--- a/spectr/changes/add-list-alias/tasks.md
+++ b/spectr/changes/add-list-alias/tasks.md
@@ -1,5 +1,0 @@
-## 1. Implementation
-
-- [ ] 1.1 Add `aliases:"ls"` tag to `ListCmd` struct in `cmd/root.go`
-- [ ] 1.2 Add test case verifying `spectr ls` works identically to `spectr list`
-- [ ] 1.3 Verify help text shows alias in command listing


### PR DESCRIPTION
## Summary
- Add `ls` as a shorthand alias for the `list` command, improving CLI ergonomics for users familiar with Unix conventions
- Users can now invoke `spectr ls` as equivalent to `spectr list`
- All existing flags (`--specs`, `--all`, `--long`, `--json`, `--interactive`) work with the alias

## Test plan
- [x] Verify `spectr ls` produces identical output to `spectr list`
- [x] Verify help text shows `list (ls)` indicating the alias is registered
- [x] Verify all flags work with the alias (`--json`, `--long`, `--help`)
- [x] Run `go test ./...` - all tests pass
- [x] Run lint - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The List command now accepts "ls" as a shorthand alias, allowing users to run `spectr ls` in place of `spectr list`
  * Updated List command help text to more accurately describe functionality
* **Tests**
  * Added test case to verify the new "ls" alias operates correctly

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->