### PR TITLE
spectr(proposal): add-provider-specific-templates

### DIFF
--- a/spectr/changes/add-provider-specific-templates/proposal.md
+++ b/spectr/changes/add-provider-specific-templates/proposal.md
@@ -1,0 +1,17 @@
+# Change: Add Provider-Specific Templates
+
+## Why
+Different AI coding tools (Claude Code, Crush, Cursor, etc.) have different tool names, agent loops, and instruction styles. The current single-template approach produces generic instructions that don't leverage provider-specific capabilities or terminology (e.g., "View" vs "cat", "Edit" vs "write", agent delegation patterns).
+
+## What Changes
+- Introduce per-provider template directories: `templates/{provider-id}/`
+- Each provider can override any template: `AGENTS.md.tmpl`, `instruction-pointer.md.tmpl`, `slash-proposal.md.tmpl`, `slash-apply.md.tmpl`
+- Generic templates remain as fallback for providers without custom templates
+- `TemplateManager` resolves templates with provider-first lookup, then generic fallback
+
+## Impact
+- Affected specs: `cli-framework` (template resolution logic)
+- Affected code:
+  - `internal/initialize/templates.go` - template resolution logic
+  - `internal/initialize/providers/provider.go` - pass provider ID to template renderer
+  - `internal/initialize/templates/` - new provider subdirectories

--- a/spectr/changes/add-provider-specific-templates/specs/cli-framework/spec.md
+++ b/spectr/changes/add-provider-specific-templates/specs/cli-framework/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Provider-Specific Template Resolution
+The template system SHALL support per-provider template overrides with fallback to generic templates.
+
+#### Scenario: Provider with custom AGENTS.md template
+- **WHEN** rendering AGENTS.md for a provider with `templates/{provider-id}/AGENTS.md.tmpl`
+- **THEN** the system uses the provider-specific template
+- **AND** the output reflects provider-specific tool names and patterns
+
+#### Scenario: Provider without custom template falls back to generic
+- **WHEN** rendering AGENTS.md for a provider without a custom template
+- **THEN** the system uses `templates/spectr/AGENTS.md.tmpl` (generic)
+- **AND** the provider still receives valid instructions
+
+#### Scenario: Partial override (some templates custom, some generic)
+- **WHEN** a provider has `templates/{provider-id}/AGENTS.md.tmpl` but no `slash-proposal.md.tmpl`
+- **THEN** AGENTS.md uses the custom template
+- **AND** slash-proposal uses the generic `templates/tools/slash-proposal.md.tmpl`
+
+### Requirement: Provider-Specific Template Directory Structure
+The template system SHALL organize provider templates in dedicated directories.
+
+#### Scenario: Template directory layout
+- **WHEN** the template system initializes
+- **THEN** it recognizes the structure:
+  ```
+  templates/
+  ├── spectr/           # Generic templates (fallback)
+  │   ├── AGENTS.md.tmpl
+  │   ├── instruction-pointer.md.tmpl
+  │   └── project.md.tmpl
+  ├── tools/            # Generic slash commands (fallback)
+  │   ├── slash-proposal.md.tmpl
+  │   └── slash-apply.md.tmpl
+  ├── claude-code/      # Provider-specific overrides
+  │   ├── AGENTS.md.tmpl
+  │   └── slash-proposal.md.tmpl
+  ├── crush/
+  │   └── AGENTS.md.tmpl
+  └── ci/
+      └── spectr-ci.yml.tmpl
+  ```
+
+#### Scenario: Provider ID mapping to directory
+- **WHEN** resolving templates for provider `claude-code`
+- **THEN** the system looks in `templates/claude-code/` first
+- **AND** falls back to generic directories if not found
+
+### Requirement: Template Renderer Provider Context
+The TemplateRenderer interface SHALL accept provider context for resolution.
+
+#### Scenario: Render with provider ID
+- **WHEN** a provider calls `RenderAgents(ctx, providerID)`
+- **THEN** the renderer uses the provider ID to select the appropriate template
+- **AND** the template context variables are still populated correctly
+
+#### Scenario: Backward compatibility for generic rendering
+- **WHEN** `RenderAgents(ctx, "")` is called with empty provider ID
+- **THEN** the system uses the generic template
+- **AND** existing behavior is preserved

--- a/spectr/changes/add-provider-specific-templates/tasks.md
+++ b/spectr/changes/add-provider-specific-templates/tasks.md
@@ -1,0 +1,28 @@
+## 1. Template Resolution Infrastructure
+
+- [ ] 1.1 Update `TemplateRenderer` interface to accept provider ID parameter
+- [ ] 1.2 Implement provider-first template lookup in `TemplateManager`
+- [ ] 1.3 Add helper function to resolve template path with fallback logic
+- [ ] 1.4 Write unit tests for template resolution with/without provider overrides
+
+## 2. Provider Integration
+
+- [ ] 2.1 Update `BaseProvider.Configure()` to pass provider ID to template renderer
+- [ ] 2.2 Update all `TemplateRenderer` method signatures
+- [ ] 2.3 Ensure backward compatibility (empty provider ID = generic)
+- [ ] 2.4 Write integration tests for provider-specific template rendering
+
+## 3. Initial Provider Templates
+
+- [ ] 3.1 Create `templates/claude-code/` directory structure
+- [ ] 3.2 Create Claude Code-specific `AGENTS.md.tmpl` with tool-specific references
+- [ ] 3.3 Create `templates/crush/` directory structure  
+- [ ] 3.4 Create Crush-specific `AGENTS.md.tmpl` with agent delegation patterns
+- [ ] 3.5 Verify `spectr init` produces provider-appropriate output
+
+## 4. Validation & Documentation
+
+- [ ] 4.1 Run full test suite (`go test ./...`)
+- [ ] 4.2 Test `spectr init` with claude-code and crush providers
+- [ ] 4.3 Verify fallback works for providers without custom templates
+- [ ] 4.4 Update provider documentation comments if needed


### PR DESCRIPTION
## Summary

Proposal for review: `add-provider-specific-templates`

**Location**: `spectr/changes/add-provider-specific-templates/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for provider-specific templates, enabling customization of template output per provider while maintaining generic templates as fallback.
  * Template resolution now prioritizes provider-specific overrides for key templates including agents, instructions, and proposals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->