### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   spectr-validate:
     name: Spectr Validate


### PR DESCRIPTION
Potential fix for [https://github.com/connerohnesorge/spectr/security/code-scanning/2](https://github.com/connerohnesorge/spectr/security/code-scanning/2)

To fix the problem, declare the `permissions` block explicitly in the workflow configuration. The minimal required permission is typically `contents: read`, allowing the Actions jobs to check out code but not modify repository contents or perform sensitive write actions. Since all jobs shown (including `lint`, which is highlighted) only perform read or local build/test actions, root-level permission declaration is optimal: it makes the configuration simpler and ensures all jobs are limited unless individually overridden. 

**Steps:**
- At the root of `.github/workflows/ci.yml` (after the `on:` and before `jobs:`), add the block:
  ```yaml
  permissions:
    contents: read
  ```
- No changes to steps, imports, or job-specific blocks are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow security configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->