### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 # Cancel in-progress runs for the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/connerohnesorge/spectr/security/code-scanning/3](https://github.com/connerohnesorge/spectr/security/code-scanning/3)

To fix the problem, set the `permissions` key in the workflow to restrict the GITHUB_TOKEN to the least-privilege necessary. In this case, that is likely `contents: read`, since jobs only check out code and do not interact with issues, pull requests, or other privileged APIs. The `permissions` key should be added at the top level of the workflow file—immediately after the trigger (`on:`) and before any jobs or steps—so that all jobs inherit this setting unless overridden. No other code changes are necessary, and this will not affect workflow functionality unless write access was unintentionally relied on (not visible in the snippet). No method or package imports are required. Only .github/workflows/ci.yml needs to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
