### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
 
   format-check:
     name: Format Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/connerohnesorge/spectr/security/code-scanning/4](https://github.com/connerohnesorge/spectr/security/code-scanning/4)

To resolve the issue, add a `permissions` block to the `format-check` job, specifying only the minimal required permissions. For jobs that only check formatting and do not interact with the repository or GitHub API (beyond possibly reading the code), this is usually:
```yaml
permissions:
  contents: read
```
Make this edit directly in `.github/workflows/ci.yml`, right under the `format-check:` job definition (between lines 69 and 70 or just after `name:`). This will limit the `GITHUB_TOKEN` to only read repository contents during this job, which is the most restrictive and secure option for the described job steps.

No new methods, imports, or variable definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
