### PR TITLE
chore(ci): migrate to Determinate Nix installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v24
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
+        uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
@@ -58,11 +54,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v24
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
+        uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
@@ -80,11 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v24
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
+        uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v13
@@ -120,11 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v24
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            accept-flake-config = true
+        uses: DeterminateSystems/determinate-nix-action@v3
 
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v13


### PR DESCRIPTION
## Summary
- Replace `cachix/install-nix-action@v24` with `DeterminateSystems/determinate-nix-action@v3` in all CI jobs
- Remove unnecessary `extra_nix_config` block (Determinate Nix has flakes enabled by default)
- Jobs updated: lint, test, format-check, build

## Test plan
- [ ] Verify CI workflows run successfully with the new installer
- [ ] Confirm Nix commands work without explicit flake configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration tooling to enhance build system reliability and consistency across workflow jobs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->