### PR TITLE
Remove clipboard writing tests

### DIFF
--- a/internal/initialize/wizard_test.go
+++ b/internal/initialize/wizard_test.go
@@ -513,45 +513,6 @@ func findSubstring(s, substr string) bool {
 	return false
 }
 
-func TestHandleCompleteKeysCopyOnSuccess(
-	t *testing.T,
-) {
-	// Test that pressing 'c' on success screen (m.err == nil) returns tea.Quit
-	cmd := &InitCmd{Path: "/tmp/test-project"}
-	wizard, err := NewWizardModel(cmd)
-	if err != nil {
-		t.Fatalf(
-			"Failed to create wizard model: %v",
-			err,
-		)
-	}
-
-	// Set up success state (no error)
-	wizard.step = StepComplete
-	wizard.err = nil
-	wizard.executionResult = &ExecutionResult{
-		CreatedFiles: []string{
-			"spectr/project.md",
-		},
-		UpdatedFiles: make([]string, 0),
-		Errors:       make([]string, 0),
-	}
-
-	// Simulate pressing 'c' key
-	keyMsg := tea.KeyMsg{
-		Type:  tea.KeyRunes,
-		Runes: []rune{'c'},
-	}
-	_, resultCmd := wizard.Update(keyMsg)
-
-	// Verify tea.Quit is returned
-	if resultCmd == nil {
-		t.Error(
-			"Expected tea.Quit command to be returned when pressing 'c' on success screen",
-		)
-	}
-}
-
 func TestHandleCompleteKeysCopyOnError(
 	t *testing.T,
 ) {

--- a/internal/list/interactive_test.go
+++ b/internal/list/interactive_test.go
@@ -3934,34 +3934,3 @@ func TestInteractiveModel_HandleEnter_StdoutMode(
 		)
 	}
 }
-
-// TestInteractiveModel_HandleEnter_NormalMode tests that handleEnter() in normal mode
-// sets both selectedID and copied flag
-func TestInteractiveModel_HandleEnter_NormalMode(
-	t *testing.T,
-) {
-	model := interactiveModel{
-		stdoutMode: false,
-		table: createMockTable([][]string{
-			{"test-id", "Test Title", "2"},
-		}),
-	}
-
-	updatedModel := model.handleEnter()
-
-	// Should have selected ID
-	if updatedModel.selectedID != "test-id" {
-		t.Errorf(
-			"selectedID = %q, want %q",
-			updatedModel.selectedID,
-			"test-id",
-		)
-	}
-
-	// Should have copied flag set in normal mode
-	if !updatedModel.copied {
-		t.Error(
-			"Expected copied to be true in normal mode",
-		)
-	}
-}


### PR DESCRIPTION
Removed two tests that performed actual writes to the system clipboard:
- TestHandleCompleteKeysCopyOnSuccess from internal/initialize/wizard_test.go
- TestInteractiveModel_HandleEnter_NormalMode from internal/list/interactive_test.go

These tests triggered clipboard.WriteAll() calls which modified the system clipboard state during test runs. Remaining tests either operate in stdout/selection modes or only test rendering, avoiding actual clipboard writes.