### PR TITLE
Add GitHub releases installation to docs

### DIFF
--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -3,9 +3,40 @@ title: Installation
 description: How to install Spectr
 ---
 
+## Using GitHub Releases
+
+The easiest way to install Spectr is to download a pre-built binary from [GitHub Releases](https://github.com/connerohnesorge/spectr/releases):
+
+```bash
+# Download the latest release for your platform
+# Replace {VERSION} with the desired version (e.g., v1.0.0)
+# Replace {OS} and {ARCH} with your platform (e.g., Linux_x86_64, Darwin_arm64)
+
+# For Linux x86_64:
+curl -LO https://github.com/connerohnesorge/spectr/releases/download/{VERSION}/spectr_{OS}_{ARCH}.tar.gz
+tar -xzf spectr_{OS}_{ARCH}.tar.gz
+sudo mv spectr /usr/local/bin/
+
+# For macOS arm64 (Apple Silicon):
+curl -LO https://github.com/connerohnesorge/spectr/releases/download/v1.0.0/spectr_Darwin_arm64.tar.gz
+tar -xzf spectr_Darwin_arm64.tar.gz
+sudo mv spectr /usr/local/bin/
+
+# For Windows (PowerShell):
+# Download the .zip file from the releases page and extract it
+# Then add the directory containing spectr.exe to your PATH
+```
+
+### Available Platforms
+
+Pre-built binaries are available for:
+- **Linux**: x86_64 (amd64), arm64
+- **macOS**: x86_64 (Intel), arm64 (Apple Silicon)
+- **Windows**: x86_64 (amd64), arm64
+
 ## Using Nix Flakes
 
-The recommended way to install Spectr is via Nix flakes:
+Alternatively, you can install Spectr via Nix flakes:
 
 ```bash
 # Run directly without installing


### PR DESCRIPTION
Add comprehensive installation instructions for downloading pre-built binaries from GitHub releases via the goreleaser workflow. This includes:
- Step-by-step download and installation commands for Linux, macOS, and Windows
- List of all available platforms and architectures
- Links to the GitHub releases page
- Reorganized installation methods with GitHub releases as the primary option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded installation guide with step-by-step instructions for GitHub Releases across Linux, macOS, and Windows, including supported platforms and architectures.
  * Added requirements section listing prerequisites.
  * Included new "Building from Source" guide for developers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->