### PR TITLE
spectr(proposal): remove-strict-flag

### DIFF
--- a/spectr/changes/remove-strict-flag/proposal.md
+++ b/spectr/changes/remove-strict-flag/proposal.md
@@ -1,0 +1,45 @@
+# Remove --strict Flag: Always Validate Strictly
+
+## Summary
+
+Remove the `--strict` flag from the `spectr validate` command and make strict validation (warnings treated as errors) the default and only behavior. This simplifies the CLI and ensures consistent validation quality across all use cases.
+
+## Motivation
+
+1. **Simplicity**: The `--strict` flag adds cognitive overhead without providing significant value. Users rarely need lenient validation.
+2. **Quality Enforcement**: Strict validation catches more issues upfront, improving spec quality.
+3. **CI/CD Consistency**: Removes the risk of different validation behavior between local development and CI pipelines.
+4. **Reduced API Surface**: One less flag to document, test, and maintain.
+
+## Changes
+
+### Behavioral Changes
+
+1. Validation always treats warnings as errors (strict mode)
+2. Exit code is 1 if any warnings or errors exist
+3. The `--strict` flag is removed from the CLI
+
+### Affected Components
+
+- `cmd/validate.go`: Remove `Strict` field and always pass `true` to validator
+- `internal/validation/validator.go`: Simplify or remove strict mode handling
+- `internal/validation/spec_rules.go`: Always apply warning-to-error conversion
+- `internal/validation/change_rules.go`: Always apply warning-to-error conversion
+- `internal/validation/interactive.go`: Remove strict parameter
+- `spectr/specs/cli-interface/spec.md`: Update specification
+- `spectr/specs/validation/spec.md`: Update specification
+- `spectr/specs/documentation/spec.md`: Update specification to remove --strict reference
+
+## Backward Compatibility
+
+This is a **breaking change** for users who:
+1. Rely on lenient validation to pass with warnings
+2. Have CI/CD pipelines using `--strict` flag (will fail with "unknown flag" error)
+
+**Migration path**: Users should fix warnings in their specs before upgrading, or remove `--strict` from their CI commands.
+
+## Alternatives Considered
+
+1. **Keep as-is**: Rejected because strict mode is the recommended practice and should be the default.
+2. **Add `--lenient` flag instead**: Rejected as it increases complexity without strong use case.
+3. **Default to strict with `--lenient` opt-out**: Rejected as unnecessary complexity.

--- a/spectr/changes/remove-strict-flag/specs/cli-interface/spec.md
+++ b/spectr/changes/remove-strict-flag/specs/cli-interface/spec.md
@@ -1,0 +1,51 @@
+# CLI Interface Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Validate Command Flags
+The validate command SHALL support flags for controlling validation behavior and output format. Validation always treats warnings as errors.
+
+#### Scenario: Default validation behavior (always strict)
+- WHEN user runs `spectr validate <item>` without any strict flag
+- THEN validation SHALL treat warnings as errors
+- AND exit code SHALL be 1 if warnings or errors exist
+- AND validation report SHALL show valid=false for any issues
+
+#### Scenario: JSON output flag
+- WHEN user provides `--json` flag
+- THEN output SHALL be formatted as JSON
+- AND SHALL include items, summary, and version fields
+- AND SHALL be parseable by standard JSON tools
+
+#### Scenario: Type disambiguation flag
+- WHEN user provides `--type change` or `--type spec`
+- THEN the command SHALL treat the item as the specified type
+- AND SHALL skip type auto-detection
+- AND SHALL error if item does not exist as that type
+
+#### Scenario: All items flag
+- WHEN user provides `--all` flag
+- THEN the command SHALL validate all changes and all specs
+- AND SHALL run in bulk validation mode
+
+#### Scenario: Changes only flag
+- WHEN user provides `--changes` flag
+- THEN the command SHALL validate all changes only
+- AND SHALL skip specs
+
+#### Scenario: Specs only flag
+- WHEN user provides `--specs` flag
+- THEN the command SHALL validate all specs only
+- AND SHALL skip changes
+
+#### Scenario: Non-interactive flag
+- WHEN user provides `--no-interactive` flag
+- THEN the command SHALL not prompt for input
+- AND SHALL print usage hint if no item specified
+- AND SHALL exit with code 1
+
+#### Scenario: Strict flag rejected as unknown
+- WHEN user provides `--strict` flag
+- THEN the command SHALL reject the flag as unknown
+- AND SHALL display an error message indicating unknown flag
+- AND the flag SHALL NOT appear in help output

--- a/spectr/changes/remove-strict-flag/specs/documentation/spec.md
+++ b/spectr/changes/remove-strict-flag/specs/documentation/spec.md
@@ -1,0 +1,38 @@
+# Documentation Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Complete Command Reference
+The system SHALL document all CLI commands with flags, examples, and expected output. Documentation SHALL only reference commands that actually exist in the CLI. Documentation SHALL distinguish between instructions for human users and AI agents.
+
+#### Scenario: User learns init command usage
+- **WHEN** a user reads the init command documentation
+- **THEN** they SHALL see all available flags (`--path`, `--tools`, `--non-interactive`) with explanations and examples
+
+#### Scenario: User learns list command options
+- **WHEN** a user reads the list command documentation
+- **THEN** they SHALL understand the `--specs`, `--json`, and `--long` flags with example outputs
+
+#### Scenario: User learns validate command options
+- **WHEN** a user reads the validate command documentation
+- **THEN** they SHALL understand that validation always treats warnings as errors
+- **AND** they SHALL see available flags (`--json`, `--type`, `--all`, `--changes`, `--specs`, `--no-interactive`) with explanations
+
+#### Scenario: User learns archive command
+- **WHEN** a user reads the archive command documentation
+- **THEN** they SHALL understand the archiving workflow and `--skip-specs` flag usage
+
+#### Scenario: User learns view command options
+- **WHEN** a user reads the view command documentation
+- **THEN** they SHALL understand the `--json` flag for dashboard output
+
+#### Scenario: Documentation accuracy
+- **WHEN** a user or AI assistant reads any documentation file
+- **THEN** all referenced CLI commands SHALL exist and work as documented
+- **AND** no nonexistent commands (such as `spectr show`) SHALL be referenced
+
+#### Scenario: AI agent documentation uses direct file reading
+- **WHEN** an AI agent reads documentation for viewing specs or changes
+- **THEN** the documentation SHALL instruct agents to read files directly (e.g., `spectr/specs/<capability>/spec.md` or `spectr/changes/<change-id>/proposal.md`)
+- **AND** the documentation SHALL NOT instruct agents to use CLI commands like `spectr view` for reading content
+- **AND** the `spectr view` command SHALL only be documented for human users

--- a/spectr/changes/remove-strict-flag/specs/validation/spec.md
+++ b/spectr/changes/remove-strict-flag/specs/validation/spec.md
@@ -1,0 +1,26 @@
+# Validation Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Validation Report Structure
+The validation system SHALL produce structured validation reports containing issue details and summary statistics, always treating warnings as errors.
+
+#### Scenario: Report always strict
+- WHEN validation encounters WARNING level issues
+- THEN the report SHALL treat warnings as errors
+- AND valid SHALL be false if errors OR warnings exist
+- AND exit code SHALL be non-zero for warnings
+- AND there is no opt-in strict mode flag
+
+#### Scenario: Report with errors and warnings
+- WHEN validation encounters both ERROR and WARNING level issues
+- THEN the report SHALL list all issues with level, path, and message
+- AND the summary SHALL count errors (including promoted warnings), warnings (always 0), and info separately
+- AND valid SHALL be false if any errors exist
+
+#### Scenario: JSON output format
+- WHEN validation is invoked with --json flag
+- THEN the output SHALL be valid JSON
+- AND SHALL include items array with per-item results
+- AND SHALL include summary with totals and byType breakdowns
+- AND SHALL include version field for format compatibility

--- a/spectr/changes/remove-strict-flag/tasks.md
+++ b/spectr/changes/remove-strict-flag/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## Implementation
+
+- [ ] 1. Update `cmd/validate.go` to remove `Strict` field from `ValidateCmd` struct
+- [ ] 2. Update `cmd/validate.go` to always pass `true` to `NewValidator()`
+- [ ] 3. Update `internal/validation/interactive.go` to remove strict parameter from `RunInteractiveValidation()`
+- [ ] 4. Update `internal/validation/validator.go` to remove `strictMode` field and always behave strictly
+- [ ] 5. Update `internal/validation/spec_rules.go` to always apply warning-to-error conversion
+- [ ] 6. Update `internal/validation/change_rules.go` to always apply warning-to-error conversion
+
+## Testing
+
+- [ ] 7. Update `internal/validation/validator_test.go` to remove strict mode tests and verify always-strict behavior
+- [ ] 8. Run `go test ./...` to verify all tests pass
+- [ ] 9. Run `go build ./...` to verify build succeeds
+
+## Documentation
+
+- [ ] 10. Update `docs/src/content/docs/reference/cli-commands.md` to remove `--strict` flag documentation
+- [ ] 11. Update `README.md` to remove any `--strict` flag examples
+
+## Validation
+
+- [ ] 12. Run `spectr validate remove-strict-flag` to validate this change (using current strict mode)
+- [ ] 13. Test CLI to verify `--strict` flag is rejected as unknown


### PR DESCRIPTION
## Summary

Proposal for review: `remove-strict-flag`

**Location**: `spectr/changes/remove-strict-flag/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `--strict` flag; strict validation is now the default and only mode for validation
  * Warnings are now treated as errors in validation reports
  * Non-zero exit codes are issued when any warnings or errors are detected
  * Migration required for CI/CD pipelines and validation scripts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->