### PR TITLE
spectr(proposal): remove-track-command

### DIFF
--- a/spectr/changes/remove-track-command/proposal.md
+++ b/spectr/changes/remove-track-command/proposal.md
@@ -1,0 +1,36 @@
+# Change: Remove Track Command
+
+## Summary
+
+Fully remove the `spectr track` subcommand from the CLI. This is a hard breaking change that removes the command entirely along with its supporting infrastructure.
+
+## Motivation
+
+The `spectr track` command provides automated git commits when task statuses change in `tasks.jsonc`. This feature is being removed to simplify the CLI and reduce maintenance burden.
+
+## Scope
+
+### Code Removal
+- Remove `cmd/track.go` - Track command implementation
+- Remove `cmd/track_test.go` - Track command tests
+- Remove `internal/track/` package - All track-related infrastructure:
+  - `tracker.go`, `tracker_test.go`
+  - `watcher.go`, `watcher_test.go`
+  - `committer.go`, `committer_test.go`
+  - `doc.go`
+- Remove `internal/specterrs/track.go` - Track-specific error types
+- Remove `TrackCmd` from `cmd/root.go` CLI struct
+
+### Spec Updates
+- Remove "Track Command" requirement from `cli-interface` spec
+- Remove "Track Command Flags" requirement from `cli-interface` spec
+
+## Breaking Change
+
+This is an intentional breaking change. Users who depend on `spectr track` will need to implement their own automation if required.
+
+## Non-Goals
+
+- Backward compatibility documentation
+- Migration path
+- Deprecation warnings

--- a/spectr/changes/remove-track-command/specs/cli-interface/spec.md
+++ b/spectr/changes/remove-track-command/specs/cli-interface/spec.md
@@ -1,0 +1,86 @@
+# Cli Interface Delta Spec
+
+## REMOVED Requirements
+
+### Requirement: Track Command
+The CLI SHALL provide a `track` command that watches task status changes and automatically commits related changes.
+
+#### Scenario: Track with change ID
+- **WHEN** user runs `spectr track <change-id>`
+- **THEN** the system watches tasks.json for the specified change
+- **AND** displays current task status (X/Y completed)
+- **AND** runs until all tasks are complete or interrupted
+
+#### Scenario: Interactive track selection
+- **WHEN** user runs `spectr track` without specifying a change ID
+- **THEN** the system displays a list of active changes with tasks.json
+- **AND** prompts for selection
+
+#### Scenario: Auto-commit on task completion
+- **WHEN** a task status changes to "completed" in tasks.json
+- **THEN** the system detects modified files via git status
+- **AND** stages all modified files except tasks.json, tasks.jsonc, tasks.md
+- **AND** creates a commit with message format: `spectr(<change-id>): complete task <task-id>`
+- **AND** includes footer: `[Automated by spectr track]`
+
+#### Scenario: Auto-commit on task start
+- **WHEN** a task status changes to "in_progress" in tasks.json
+- **THEN** the system detects modified files via git status
+- **AND** stages all modified files except tasks.json, tasks.jsonc, tasks.md
+- **AND** creates a commit with message format: `spectr(<change-id>): start task <task-id>`
+- **AND** includes footer: `[Automated by spectr track]`
+
+#### Scenario: No files to commit warning
+- **WHEN** a task status changes but no files have been modified (excluding task files)
+- **THEN** the system prints a warning: "No files to commit for task <task-id>"
+- **AND** continues watching for more task changes
+
+#### Scenario: Git commit failure stops tracking
+- **WHEN** a git commit operation fails (e.g., merge conflict, hook rejection)
+- **THEN** the system displays the git error message
+- **AND** stops tracking immediately
+- **AND** exits with non-zero status code
+
+#### Scenario: Graceful interruption
+- **WHEN** user presses Ctrl+C during tracking
+- **THEN** the system stops watching and exits cleanly
+- **AND** displays "Tracking stopped" message
+
+#### Scenario: All tasks already complete
+- **WHEN** user runs `spectr track <change-id>` and all tasks are already completed
+- **THEN** the system displays a message indicating all tasks are complete
+- **AND** exits without starting the watch loop
+
+### Requirement: Track Command Flags
+The track command SHALL support flags for controlling behavior.
+
+#### Scenario: No-interactive flag disables prompts
+- **WHEN** user provides the `--no-interactive` flag
+- **AND** no change-id is provided
+- **THEN** the system displays usage error instead of prompting for selection
+
+### Requirement: Track Command Binary Filtering
+The track command SHALL support binary file filtering to prevent unintentional commits of binary files.
+
+#### Scenario: Include-binaries flag enables binary file commits
+- **WHEN** user provides the `--include-binaries` flag
+- **THEN** the system includes binary files in automatic commits
+- **AND** commits all modified files as before (excluding task files)
+
+#### Scenario: Default binary file exclusion
+- **WHEN** user runs `spectr track` without the `--include-binaries` flag
+- **THEN** the system detects binary files using git diff --numstat
+- **AND** excludes binary files from staging
+- **AND** displays a warning listing skipped binary files
+- **AND** continues to commit non-binary files normally
+
+#### Scenario: Binary detection via git
+- **WHEN** the system needs to determine if a file is binary
+- **THEN** it SHALL use `git diff --numstat` to check for binary markers
+- **AND** treat files with `-       -` output as binary
+
+#### Scenario: Only binary files modified
+- **WHEN** a task status changes and only binary files were modified (with no --include-binaries flag)
+- **THEN** the system displays a warning: "No files to commit for task <task-id> (binary files excluded)"
+- **AND** lists the skipped binary files
+- **AND** continues watching for more task changes

--- a/spectr/changes/remove-track-command/tasks.md
+++ b/spectr/changes/remove-track-command/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+## 1. Code Removal
+
+- [ ] 1.1 Remove `TrackCmd` field from `CLI` struct in `cmd/root.go`
+- [ ] 1.2 Delete `cmd/track.go`
+- [ ] 1.3 Delete `cmd/track_test.go`
+- [ ] 1.4 Delete entire `internal/track/` directory (tracker.go, watcher.go, committer.go, doc.go and tests)
+- [ ] 1.5 Delete `internal/specterrs/track.go` (track-specific error types)
+
+## 2. Verification
+
+- [ ] 2.1 Run `go build ./...` to verify no broken imports
+- [ ] 2.2 Run `go test ./...` to ensure all tests pass
+- [ ] 2.3 Run `golangci-lint run` to check for any linting issues


### PR DESCRIPTION
## Summary

Proposal for review: `remove-track-command`

**Location**: `spectr/changes/remove-track-command/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the track subcommand and all related tracking functionality from the CLI interface. Users currently relying on the track command for task automation will need to implement and maintain their own alternative solutions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->