### PR TITLE
spectr(proposal): add domain package and explicit registration to provider architecture

### DIFF
--- a/spectr/changes/redesign-provider-architecture/proposal.md
+++ b/spectr/changes/redesign-provider-architecture/proposal.md
@@ -18,12 +18,14 @@ The current provider system has 17 providers, each implementing a 12-method inte
 - **BREAKING**: Remove current `Provider` interface (12 methods) and `BaseProvider` struct
 - **BREAKING**: Replace with minimal `Provider` interface returning `[]Initializer`
 - **BREAKING**: Provider metadata (ID, name, priority) moves to registration time
+- **NEW**: `internal/domain` package containing shared domain types (`TemplateRef`, `SlashCommand`) to break import cycles
 - **NEW**: `Initializer` interface with `Init(ctx, fs, cfg, tm)` and `IsSetup(fs, cfg)` methods
 - **NEW**: Built-in initializers: `DirectoryInitializer`, `ConfigFileInitializer`, `SlashCommandsInitializer`
 - **NEW**: `Config` struct with `SpectrDir` field; other paths derived (SpecsDir = SpectrDir/specs, etc.)
 - **NEW**: Two filesystem instances: `projectFs` (project-relative) and `globalFs` (home directory)
 - **REMOVED**: `GetFilePaths()`, `HasConfigFile()`, `HasSlashCommands()` methods
 - **NEW**: `Initializer.Init()` returns `InitResult` containing created/updated files (explicit change tracking)
+- **CHANGED**: Provider registration uses explicit `RegisterAllProviders()` called at startup (no init() in provider files, proper error propagation)
 - **MIGRATION**: Users must re-run `spectr init` (clean break, no automatic migration)
 
 ## Key Decisions
@@ -43,9 +45,11 @@ The current provider system has 17 providers, each implementing a 12-method inte
 
 ## Affected Code
 
-- `internal/initialize/providers/*.go` - Complete rewrite
+- `internal/domain/*.go` - New domain package with shared types (`TemplateRef`, `SlashCommand`, `TemplateContext`)
+- `internal/initialize/providers/*.go` - Complete rewrite with explicit registration error handling
 - `internal/initialize/providers/initializers/*.go` - New initializer implementations
 - `internal/initialize/providers/result.go` - New InitResult type
+- `internal/initialize/templates/*.go` - Updated to use domain types from `internal/domain`
 - `internal/initialize/executor.go` - Simplified provider orchestration with result collection
 - `internal/initialize/wizard.go` - Provider selection UI unchanged
 - `cmd/init.go` - Minor updates for new API

--- a/spectr/changes/redesign-provider-architecture/specs/provider-system/spec.md
+++ b/spectr/changes/redesign-provider-architecture/specs/provider-system/spec.md
@@ -1,5 +1,25 @@
 ## ADDED Requirements
 
+### Requirement: Domain Package
+The system SHALL define a `internal/domain` package containing shared domain types to break import cycles.
+
+#### Scenario: TemplateRef in domain package
+- **WHEN** code needs to reference a template
+- **THEN** it SHALL use `domain.TemplateRef` from `internal/domain`
+- **AND** `TemplateRef` SHALL have `Name` and `Template` fields
+- **AND** `TemplateRef` SHALL have a `Render(ctx TemplateContext) (string, error)` method
+
+#### Scenario: SlashCommand in domain package
+- **WHEN** code needs to reference a slash command type
+- **THEN** it SHALL use `domain.SlashCommand` from `internal/domain`
+- **AND** `SlashCommand` SHALL be a typed constant (`SlashProposal`, `SlashApply`)
+- **AND** `SlashCommand` SHALL have `String()` and `TemplateName()` methods
+
+#### Scenario: TemplateContext in domain package
+- **WHEN** code needs template context with path variables
+- **THEN** it SHALL use `domain.TemplateContext` from `internal/domain`
+- **AND** `domain.DefaultTemplateContext()` SHALL return default path values
+
 ### Requirement: Provider Interface
 The system SHALL define a `Provider` interface that returns a list of initializers.
 
@@ -48,13 +68,21 @@ The system SHALL provide a `Config` struct containing initialization configurati
 - **AND** `ProjectFile()` SHALL return `SpectrDir + "/project.md"`
 - **AND** `AgentsFile()` SHALL return `SpectrDir + "/AGENTS.md"`
 
-### Requirement: Provider Registration
-The system SHALL support registering providers with metadata at registration time.
+### Requirement: Provider Registration (Explicit, No init())
+The system SHALL support registering providers explicitly from a central location, not via init() functions.
 
 #### Scenario: Register provider with metadata
-- **WHEN** a provider is registered
+- **WHEN** a provider is registered via `RegisterProvider(reg Registration) error`
 - **THEN** the registration SHALL include ID, Name, Priority, and Provider implementation
-- **AND** the system SHALL reject duplicate provider IDs
+- **AND** the system SHALL reject duplicate provider IDs with a clear error
+- **AND** the function SHALL return an error (not panic) for invalid registrations
+
+#### Scenario: RegisterAllProviders at startup
+- **WHEN** the application starts
+- **THEN** it SHALL call `RegisterAllProviders()` explicitly from `cmd/root.go` or `main()`
+- **AND** the function SHALL register all built-in providers in one place
+- **AND** the function SHALL return an error if any registration fails
+- **AND** individual provider files SHALL NOT contain `init()` functions for registration
 
 #### Scenario: Retrieve registered providers
 - **WHEN** providers are queried

--- a/spectr/changes/redesign-provider-architecture/tasks.md
+++ b/spectr/changes/redesign-provider-architecture/tasks.md
@@ -1,3 +1,23 @@
+## 0. Domain Package: Shared Types to Break Import Cycles
+
+Create `internal/domain` package with shared domain types that can be imported by both `providers` and `templates` packages without creating import cycles.
+
+- [ ] 0.1 Create `internal/domain/template.go` with:
+  - `TemplateRef` struct with `Name string` and `Template *template.Template` fields
+  - `Render(ctx TemplateContext) (string, error)` method on `TemplateRef`
+  - `TemplateContext` struct with `BaseDir`, `SpecsDir`, `ChangesDir`, `ProjectFile`, `AgentsFile` fields
+  - `DefaultTemplateContext()` function returning default values
+- [ ] 0.2 Create `internal/domain/slashcmd.go` with:
+  - `SlashCommand int` type with `SlashProposal`, `SlashApply` constants
+  - `String() string` method for debugging
+  - `TemplateName() string` method returning the .tmpl file name
+- [ ] 0.3 Add unit tests for `internal/domain/template_test.go`:
+  - Test `TemplateRef.Render()` with mock template
+  - Test `DefaultTemplateContext()` returns expected values
+- [ ] 0.4 Add unit tests for `internal/domain/slashcmd_test.go`:
+  - Test `SlashCommand.String()` returns correct names
+  - Test `SlashCommand.TemplateName()` returns correct template file names
+
 ## 1. Foundation: Core Interfaces and Types
 
 These tasks establish the new architecture without breaking the existing code.
@@ -16,29 +36,26 @@ These tasks establish the new architecture without breaking the existing code.
   - `ChangesDir() string` method (returns SpectrDir + "/changes")
   - `ProjectFile() string` method (returns SpectrDir + "/project.md")
   - `AgentsFile() string` method (returns SpectrDir + "/AGENTS.md")
-- [ ] 1.4 Create `internal/initialize/providers/provider_new.go` with new minimal `Provider` interface returning `[]Initializer`
-- [ ] 1.5 Create `internal/initialize/providers/registration.go` with `Registration` struct (ID, Name, Priority, Provider) and new registration API
+- [ ] 1.4 Rewrite `internal/initialize/providers/provider.go` with new minimal `Provider` interface returning `[]Initializer` (replace old interface in-place)
+- [ ] 1.5 Create `internal/initialize/providers/registration.go` with:
+  - `Registration` struct (ID, Name, Priority, Provider)
+  - `RegisterProvider(reg Registration) error` function with validation
+  - `RegisterAllProviders() error` function that registers all built-in providers explicitly (no init())
+  - Registry data structure and accessor functions (`Get`, `All`, `IDs`, `Count`)
 
 ## 2. Type-Safe Template System
 
-Create the type-safe template selection infrastructure before building initializers.
+Update TemplateManager to use domain types and add type-safe accessor methods.
 
-- [ ] 2.1 Create `internal/initialize/templates/ref.go` with `TemplateRef` type:
-  - `name string` field (template file name)
-  - `template *template.Template` field (parsed template reference)
-  - `Render(ctx TemplateContext) (string, error)` method
-- [ ] 2.2 Add type-safe accessor methods to `TemplateManager`:
-  - `InstructionPointer() TemplateRef`
-  - `Agents() TemplateRef`
-  - `Project() TemplateRef`
-  - `CIWorkflow() TemplateRef`
-- [ ] 2.3 Create `internal/initialize/templates/slashcmd.go` with `SlashCommand` type:
-  - `SlashCommand int` type with `SlashProposal`, `SlashApply` constants
-  - `String() string` method for debugging
-  - `TemplateName() string` method returning the .tmpl file name
-- [ ] 2.4 Add `SlashCommand(cmd SlashCommand) TemplateRef` method to `TemplateManager`
-- [ ] 2.5 Add unit tests for `TemplateRef.Render()` with mock templates
-- [ ] 2.6 Add unit tests verifying all accessor methods return valid `TemplateRef`
+- [ ] 2.1 Update `internal/initialize/templates.go` to import and use `domain.TemplateRef` and `domain.TemplateContext`
+- [ ] 2.2 Add type-safe accessor methods to `TemplateManager` returning `domain.TemplateRef`:
+  - `InstructionPointer() domain.TemplateRef`
+  - `Agents() domain.TemplateRef`
+  - `Project() domain.TemplateRef`
+  - `CIWorkflow() domain.TemplateRef`
+- [ ] 2.3 Add `SlashCommand(cmd domain.SlashCommand) domain.TemplateRef` method to `TemplateManager`
+- [ ] 2.4 Add unit tests verifying all accessor methods return valid `domain.TemplateRef`
+- [ ] 2.5 Update any existing code that uses TemplateContext to use `domain.TemplateContext`
 
 ## 3. Built-in Initializers
 
@@ -50,51 +67,55 @@ Create the three composable initializers that providers will use. Each must impl
   - Creates directories with `MkdirAll`
 - [ ] 3.2 Create `internal/initialize/providers/initializers/configfile.go` with `ConfigFileInitializer`:
   - Implements `Init()`, `IsSetup()`, `Path()`, `IsGlobal()`
-  - Receives `TemplateGetter func(*TemplateManager) TemplateRef` (compile-time checked)
+  - Receives `TemplateGetter func(*TemplateManager) domain.TemplateRef` (compile-time checked)
   - Handles both create and update scenarios with marker-based updates
 - [ ] 3.3 Create `internal/initialize/providers/initializers/slashcmds.go` with `SlashCommandsInitializer`:
   - Implements `Init()`, `IsSetup()`, `Path()`, `IsGlobal()`
-  - Receives `[]SlashCommand` (compile-time checked command types)
+  - Receives `[]domain.SlashCommand` (compile-time checked command types from domain package)
   - Supports both Markdown and TOML output formats
 - [ ] 3.4 Add unit tests for `DirectoryInitializer` with `afero.MemMapFs`
 - [ ] 3.5 Add unit tests for `ConfigFileInitializer` with `afero.MemMapFs` - test create and marker update scenarios
 - [ ] 3.6 Add unit tests for `SlashCommandsInitializer` with `afero.MemMapFs` - test Markdown and TOML formats
 
-## 4. New Registry Implementation
+## 4. New Registry Implementation (No init())
 
-Replace the old registry with metadata-separated registration.
+Replace the old registry with explicit registration - no init() functions in provider files. Replace in-place, do not create V2 files.
 
-- [ ] 4.1 Create `internal/initialize/providers/registry_v2.go` with new `Registry` type using `Registration` struct for metadata
-- [ ] 4.2 Implement `Register(Registration)`, `Get(id)`, `All()`, `IDs()`, `Count()` methods on new registry
-- [ ] 4.3 Add priority-sorted retrieval maintaining backwards-compatible behavior
-- [ ] 4.4 Add duplicate ID rejection with clear error messages
-- [ ] 4.5 Add unit tests for new registry: registration, retrieval, priority sorting, duplicate rejection
+- [ ] 4.1 Rewrite `internal/initialize/providers/registry.go` with new `Registry` type using `Registration` struct for metadata
+- [ ] 4.2 Implement `RegisterProvider(reg Registration) error` with validation (returns error, not panic)
+- [ ] 4.3 Implement `Get(id)`, `All()`, `IDs()`, `Count()` methods on registry
+- [ ] 4.4 Add priority-sorted retrieval maintaining backwards-compatible behavior
+- [ ] 4.5 Add duplicate ID rejection with clear error messages
+- [ ] 4.6 Create `RegisterAllProviders() error` function that explicitly registers all 17 providers in one place
+- [ ] 4.7 Rewrite `registry_test.go` with tests for new registry: registration, retrieval, priority sorting, duplicate rejection
+- [ ] 4.8 Add unit tests for `RegisterAllProviders()` verifying all providers are registered correctly
 
-## 5. Migrate Providers (In-Place Replacement)
+## 5. Migrate Providers (In-Place Replacement, No init())
 
-Migrate each provider to the new interface, deleting old code as each migration completes.
+Migrate each provider to the new interface. Each provider file should ONLY contain the struct and Initializers() method - NO init() function. Registration happens in `RegisterAllProviders()`.
 
-- [ ] 5.1 Migrate `claude.go` to new Provider interface (reference implementation) - delete old `ClaudeProvider` struct and `NewClaudeProvider()` after migration
-- [ ] 5.2 Migrate `gemini.go` to new Provider interface (TOML format example) - delete old `GeminiProvider` struct and `Configure()` override after migration
-- [ ] 5.3 Migrate `cursor.go` to new Provider interface - delete old code
-- [ ] 5.4 Migrate `cline.go` to new Provider interface - delete old code
-- [ ] 5.5 Migrate `aider.go` to new Provider interface - delete old code
-- [ ] 5.6 Migrate `codex.go` to new Provider interface - delete old code
-- [ ] 5.7 Migrate `costrict.go` to new Provider interface - delete old code
-- [ ] 5.8 Migrate `qoder.go` to new Provider interface - delete old code
-- [ ] 5.9 Migrate `codebuddy.go` to new Provider interface - delete old code
-- [ ] 5.10 Migrate `qwen.go` to new Provider interface - delete old code
-- [ ] 5.11 Migrate `antigravity.go` to new Provider interface - delete old code
-- [ ] 5.12 Migrate `windsurf.go` to new Provider interface - delete old code
-- [ ] 5.13 Migrate `kilocode.go` to new Provider interface - delete old code
-- [ ] 5.14 Migrate `continue.go` to new Provider interface - delete old code
-- [ ] 5.15 Migrate `crush.go` to new Provider interface - delete old code
-- [ ] 5.16 Migrate `opencode.go` to new Provider interface - delete old code
+- [ ] 5.1 Migrate `claude.go` to new Provider interface (reference implementation) - delete old struct, `NewClaudeProvider()`, and `init()`
+- [ ] 5.2 Migrate `gemini.go` to new Provider interface (TOML format example) - delete old struct, `Configure()` override, and `init()`
+- [ ] 5.3 Migrate `cursor.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.4 Migrate `cline.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.5 Migrate `aider.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.6 Migrate `codex.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.7 Migrate `costrict.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.8 Migrate `qoder.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.9 Migrate `codebuddy.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.10 Migrate `qwen.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.11 Migrate `antigravity.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.12 Migrate `windsurf.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.13 Migrate `kilocode.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.14 Migrate `continue.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.15 Migrate `crush.go` to new Provider interface - delete old code and `init()`
+- [ ] 5.16 Migrate `opencode.go` to new Provider interface - delete old code and `init()`
 
 ## 6. Executor Integration
 
 Update executor to use new architecture with dual filesystem, ordering, deduplication, and InitResult collection.
 
+- [ ] 6.0 Update `cmd/root.go` or application entry point to call `providers.RegisterAllProviders()` at startup with error handling
 - [ ] 6.1 Create dual filesystem in `executor.go`:
   - `projectFs := afero.NewBasePathFs(osFs, projectPath)` for project-relative paths
   - `globalFs := afero.NewBasePathFs(osFs, os.UserHomeDir())` for global paths
@@ -119,7 +140,7 @@ Remove deprecated code that has been replaced by the new architecture.
 - [ ] 7.1 Remove old `Provider` interface (12-method version) from `provider.go`
 - [ ] 7.2 Remove `BaseProvider` struct from `provider.go`
 - [ ] 7.3 Remove `TemplateRenderer` interface from `provider.go` (now using `*TemplateManager` directly)
-- [ ] 7.4 Remove `TemplateContext` and `DefaultTemplateContext()` from `provider.go` (move to config if needed)
+- [ ] 7.4 Remove `TemplateContext` and `DefaultTemplateContext()` from `provider.go` (now in `internal/domain`)
 - [ ] 7.5 Delete `helpers.go` - `EnsureDir`, `FileExists`, `UpdateFileWithMarkers` now in initializers or use `afero.Fs`
 - [ ] 7.6 Remove old global registry functions from `registry.go` (keep only new `Registry` type)
 - [ ] 7.7 Clean up `constants.go` - remove `StandardFrontmatter()`, `StandardCommandPaths()`, `PrefixedCommandPaths()` (moved to initializers)
@@ -127,16 +148,14 @@ Remove deprecated code that has been replaced by the new architecture.
 
 ## 8. Test Cleanup
 
-Update tests to match new architecture - explicit cleanup tasks for old test files.
+Update tests to match new architecture - rewrite in-place, no V2 files.
 
-- [ ] 8.1 Delete `provider_test.go` (~666 lines) - old interface tests no longer applicable
-- [ ] 8.2 Create `provider_new_test.go` with tests for new `Provider` interface
-- [ ] 8.3 Add tests verifying all 17 providers return expected initializers
-- [ ] 8.4 Add tests verifying provider registration metadata (ID, Name, Priority)
-- [ ] 8.5 Delete `registry_test.go` (~212 lines) - old registry tests no longer applicable
-- [ ] 8.6 Create `registry_v2_test.go` with tests for new `Registry` type
-- [ ] 8.7 Add integration test for full initialization flow using `afero.MemMapFs`
-- [ ] 8.8 Add integration test verifying InitResult accumulation
+- [ ] 8.1 Rewrite `provider_test.go` with tests for new `Provider` interface (replace old tests, not new file)
+- [ ] 8.2 Add tests verifying all 17 providers return expected initializers
+- [ ] 8.3 Add tests verifying provider registration metadata (ID, Name, Priority)
+- [ ] 8.4 Rewrite `registry_test.go` with tests for new `Registry` type (replace old tests, not new file)
+- [ ] 8.5 Add integration test for full initialization flow using `afero.MemMapFs`
+- [ ] 8.6 Add integration test verifying InitResult accumulation
 
 ## 9. Final Verification
 


### PR DESCRIPTION
## Summary

Enhanced the `redesign-provider-architecture` proposal with implementation details for two critical improvements:

### 1. Domain Package (`internal/domain`)

**Problem:** Import cycle between `providers.TemplateManager` and `internal/initialize/templates`
- TemplateManager needs `TemplateRef` and `SlashCommand` types
- Currently uses `any` as placeholder with concrete adapter explaining real types

**Solution:** New `internal/domain` package containing:
- `TemplateRef` - type-safe template reference with `Render()` method
- `SlashCommand` - typed constants (`SlashProposal`, `SlashApply`) with helper methods
- `TemplateContext` - shared path variables

**Benefits:**
- No import cycles (domain has no internal dependencies)
- Compile-time type safety for template selection
- Clear separation of domain types from implementation

### 2. Explicit Registration (No `init()`)

**Problem:** Provider registration silently discards errors
```go
// Current (BAD)
func init() {
    Register(NewOpencodeProvider())  // Error ignored!
}
```

**Solution:** Central registration with proper error handling
```go
// New (GOOD)
func RegisterAllProviders() error {
    providers := []Registration{
        {ID: "claude-code", Name: "Claude Code", Priority: 1, Provider: &ClaudeProvider{}},
        // ... all 17 providers
    }
    for _, reg := range providers {
        if err := RegisterProvider(reg); err != nil {
            return fmt.Errorf("failed to register %s: %w", reg.ID, err)
        }
    }
    return nil
}
```

Called at startup from `cmd/root.go` or `main()`.

**Benefits:**
- Testable (can call `RegisterProvider()` individually in tests)
- Explicit error propagation (no silent failures)
- All registrations visible in one place
- Debuggable (can set breakpoints, trace execution)

## Files Changed

- `proposal.md` - Added domain package and explicit registration to "What Changes"
- `design.md` - Added section 0 (Domain Package) and rewrote section 2 (Registration API)
- `tasks.md` - Added section 0 (domain tasks), updated provider migrations to remove init()
- `specs/provider-system/spec.md` - Added requirements for domain package and explicit registration

## Zero Technical Debt

✅ No V2 naming (all replacements in-place)
✅ No temporary workarounds
✅ Clean architecture with domain-driven design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved provider initialization with explicit registration and better error handling.
  * Enhanced configuration management with structured path helpers.
  * Support for dual filesystem instances enabling more flexible file operations.

* **Chores**
  * Users must re-run `spectr init` to apply architectural updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->