### PR TITLE
spectr(proposal): add implementation details to redesign-provider-architecture

### DIFF
--- a/spectr/changes/redesign-provider-architecture/proposal.md
+++ b/spectr/changes/redesign-provider-architecture/proposal.md
@@ -13,12 +13,17 @@ The current provider system has 17 providers, each implementing a 12-method inte
 
 **Minimal viable**: Focus on reducing boilerplate while keeping behavior identical. No new features, no new instruction files (those belong in a separate proposal).
 
+**Zero technical debt policy**: Complete removal of old registration system. No compatibility shims, no deprecated functions that silently swallow calls. Clean break with compile-time errors to force explicit migration.
+
 ## What Changes
 
 - **BREAKING**: Remove current `Provider` interface (12 methods) and `BaseProvider` struct
 - **BREAKING**: Replace with minimal `Provider` interface returning `[]Initializer`
 - **BREAKING**: Provider metadata (ID, name, priority) moves to registration time
-- **NEW**: `internal/domain` package containing shared domain types (`TemplateRef`, `SlashCommand`) to break import cycles
+- **BREAKING**: **COMPLETELY REMOVE** old `Register(p Provider)` function and all `init()` registration - zero tech debt policy means NO deprecated `Register(_ any)` compatibility shim
+- **BREAKING**: Remove all provider `init()` functions that call `Register()`
+- **NEW**: `internal/domain` package containing shared domain types (`TemplateRef`, `SlashCommand`, `TemplateContext`) to break import cycles
+- **NEW**: `internal/domain` package embeds slash command templates (`slash-proposal.md.tmpl`, `slash-apply.md.tmpl`) moved from `internal/initialize/templates/tools/`
 - **NEW**: `Initializer` interface with `Init(ctx, fs, cfg, tm)` and `IsSetup(fs, cfg)` methods
 - **NEW**: Built-in initializers: `DirectoryInitializer`, `ConfigFileInitializer`, `SlashCommandsInitializer`
 - **NEW**: `Config` struct with `SpectrDir` field; other paths derived (SpecsDir = SpectrDir/specs, etc.)
@@ -46,6 +51,8 @@ The current provider system has 17 providers, each implementing a 12-method inte
 ## Affected Code
 
 - `internal/domain/*.go` - New domain package with shared types (`TemplateRef`, `SlashCommand`, `TemplateContext`)
+- `internal/domain/templates/*.tmpl` - Slash command templates moved from `internal/initialize/templates/tools/`
+- `internal/domain/templates.go` - Embed directive for domain templates
 - `internal/initialize/providers/*.go` - Complete rewrite with explicit registration error handling
 - `internal/initialize/providers/initializers/*.go` - New initializer implementations
 - `internal/initialize/providers/result.go` - New InitResult type

--- a/spectr/changes/redesign-provider-architecture/tasks.jsonc
+++ b/spectr/changes/redesign-provider-architecture/tasks.jsonc
@@ -61,6 +61,42 @@
       "status": "pending"
     },
     {
+      "id": "0.5",
+      "section": "Domain Package: Slash Command Template Consolidation",
+      "description": "Create `internal/domain/templates.go` with `//go:embed templates/*.tmpl` directive and exported `TemplateFS embed.FS` variable",
+      "status": "pending"
+    },
+    {
+      "id": "0.6",
+      "section": "Domain Package: Slash Command Template Consolidation",
+      "description": "Create directory `internal/domain/templates/` for embedded slash command templates",
+      "status": "pending"
+    },
+    {
+      "id": "0.7",
+      "section": "Domain Package: Slash Command Template Consolidation",
+      "description": "Move `internal/initialize/templates/tools/slash-proposal.md.tmpl` to `internal/domain/templates/slash-proposal.md.tmpl`",
+      "status": "pending"
+    },
+    {
+      "id": "0.8",
+      "section": "Domain Package: Slash Command Template Consolidation",
+      "description": "Move `internal/initialize/templates/tools/slash-apply.md.tmpl` to `internal/domain/templates/slash-apply.md.tmpl`",
+      "status": "pending"
+    },
+    {
+      "id": "0.9",
+      "section": "Domain Package: Slash Command Template Consolidation",
+      "description": "Verify `internal/domain/slashcmd.go` has ONLY `String()` method (NO `TemplateName()` method)",
+      "status": "pending"
+    },
+    {
+      "id": "0.10",
+      "section": "Domain Package: Slash Command Template Consolidation",
+      "description": "Delete empty `internal/initialize/templates/tools/` directory after moving slash command templates",
+      "status": "pending"
+    },
+    {
       "id": "1.1",
       "section": "Foundation: Core Interfaces and Types",
       "description": "Create `internal/initialize/providers/initializer.go` with new `Initializer` interface including:",
@@ -93,7 +129,7 @@
     {
       "id": "2.1",
       "section": "Type-Safe Template System",
-      "description": "Update `internal/initialize/templates.go` to import and use `domain.TemplateRef` and `domain.TemplateContext`",
+      "description": "Update `internal/initialize/templates.go` to import and use `domain.TemplateRef` and `domain.TemplateContext`, and merge templates from both `templateFS` (main) and `domain.TemplateFS` (slash commands) in `NewTemplateManager()`",
       "status": "pending"
     },
     {
@@ -129,7 +165,7 @@
     {
       "id": "3.2",
       "section": "Built-in Initializers",
-      "description": "Create `internal/initialize/providers/initializers/configfile.go` with `ConfigFileInitializer`:",
+      "description": "Create `internal/initialize/providers/initializers/configfile.go` with `ConfigFileInitializer` that handles orphaned markers: (1) if start marker found but end marker missing immediately after, search for trailing end marker with strings.LastIndex; (2) if trailing end found after start, use it for update; (3) if no end marker anywhere after start, replace from start marker onward with new block (prevents duplicate blocks and orphaned markers)",
       "status": "pending"
     },
     {
@@ -147,7 +183,7 @@
     {
       "id": "3.5",
       "section": "Built-in Initializers",
-      "description": "Add unit tests for `ConfigFileInitializer` with `afero.MemMapFs` - test create and marker update scenarios",
+      "description": "Add unit tests for `ConfigFileInitializer` with `afero.MemMapFs` - test: (1) create new file, (2) normal marker update (both markers present), (3) orphaned start marker with trailing end marker elsewhere, (4) orphaned start marker with no end marker anywhere (replacement scenario), (5) verify no duplicate blocks created",
       "status": "pending"
     },
     {
@@ -207,7 +243,7 @@
     {
       "id": "5.1",
       "section": "Migrate Providers (In-Place Replacement, No init())",
-      "description": "Migrate `claude.go` to new Provider interface (reference implementation) - delete old struct, `NewClaudeProvider()`, and `init()`",
+      "description": "Migrate `claude.go` to new Provider interface (reference implementation) - **DELETE** old `BaseProvider` struct, `NewClaudeProvider()`, and the entire `func init() { Register(NewClaudeProvider()) }` block - replace with simple struct implementing new `Provider` interface returning `[]Initializer`",
       "status": "pending"
     },
     {
@@ -387,7 +423,7 @@
     {
       "id": "7.6",
       "section": "Remove Old Provider Code (In-Place Cleanup)",
-      "description": "Remove old global registry functions from `registry.go` (keep only new `Registry` type)",
+      "description": "**COMPLETELY REMOVE** old global registry functions from `registry.go`: delete `Register(p Provider)`, `Get(id)`, `All()`, `IDs()`, `Count()`, `WithConfigFile()`, `WithSlashCommands()`, `Reset()` - zero tech debt policy means NO compatibility shims, NO deprecated `Register(_ any)` that silently swallows calls",
       "status": "pending"
     },
     {


### PR DESCRIPTION
## Summary

Enhanced the `redesign-provider-architecture` proposal with comprehensive implementation details based on three key decisions:

### 1. Template Consolidation (Full Consolidation) ✅

- **Move slash command templates** from `internal/initialize/templates/tools/` to `internal/domain/templates/`
- **Add embed directive** in `internal/domain/templates.go` with exported `TemplateFS`
- **Remove `TemplateName()` method** from `SlashCommand` (templates accessed via `TemplateManager.SlashCommand(cmd)`)
- **Merge templates** from both `internal/initialize` and `internal/domain` in `NewTemplateManager()`
- **Added 6 new tasks** (0.5-0.10) for complete template consolidation

### 2. Zero Technical Debt Policy 🚫

- **Complete removal** of old `Register(p Provider)` function
- **NO compatibility shims** - explicitly reject `Register(_ any)` that silently swallows calls
- **Compiler-enforced migration** - undefined function errors force explicit migration
- **Delete all `init()` functions** from provider files (tasks 5.1-5.16)
- **Added comprehensive rationale** explaining why deprecated shims violate tech debt policy
- **New spec requirement**: "Zero Technical Debt - No Compatibility Shims" with scenarios

### 3. Orphaned Marker Handling 🔧

- **Document correct logic** for `ConfigFileInitializer` marker handling (lines 188-212)
- **Three-tier fallback**:
  1. Normal case: both markers present → update between them
  2. Orphaned start + trailing end: search with `strings.LastIndex` → use trailing end
  3. Orphaned start only: replace everything from start marker onward
- **Prevents duplicate blocks** and orphaned markers
- **Added scenarios** for orphaned marker recovery in spec
- **Updated tests** to cover 5 marker handling scenarios

## Changes Made

### Files Modified
- `design.md` - Added sections on zero tech debt policy, marker handling logic, template consolidation
- `proposal.md` - Added zero tech debt statement, template consolidation details
- `specs/provider-system/spec.md` - Added orphaned marker scenarios, zero tech debt requirement
- `tasks.jsonc` - Added 6 template tasks, detailed marker handling requirements, explicit init() deletion

### Validation
✅ All changes validated with `spectr validate redesign-provider-architecture`
✅ All 39 items pass validation (3 changes, 36 specs)

## Test Plan

Implementation will verify:
- [ ] Slash command templates correctly embedded in domain package
- [ ] TemplateManager merges templates from both locations
- [ ] SlashCommand has NO TemplateName() method
- [ ] Old Register() function completely removed (compile errors if called)
- [ ] All provider init() functions deleted
- [ ] ConfigFileInitializer handles orphaned markers correctly
- [ ] No duplicate blocks created with orphaned start markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)