### PR TITLE
spectr(proposal): add-tty-error-hint

### DIFF
--- a/spectr/changes/add-tty-error-hint/proposal.md
+++ b/spectr/changes/add-tty-error-hint/proposal.md
@@ -1,0 +1,18 @@
+# Change: Add helpful hint when TTY is unavailable
+
+## Why
+When users run `spectr init` in environments without a TTY (CI pipelines, Docker containers, piped commands), they receive a cryptic error message:
+```
+spectr: error: wizard failed: could not open a new TTY: open /dev/tty: no such device or address
+```
+
+This provides no guidance on how to resolve the issue, leaving users to search for documentation or guess at solutions.
+
+## What Changes
+- Detect TTY-related errors from the Bubbletea TUI framework
+- Enhance the error message with a helpful hint suggesting `--non-interactive` flag usage
+- Provide a concrete example command in the error output
+
+## Impact
+- Affected specs: `cli-interface`
+- Affected code: `cmd/init.go` (runInteractiveInit function)

--- a/spectr/changes/add-tty-error-hint/specs/cli-interface/spec.md
+++ b/spectr/changes/add-tty-error-hint/specs/cli-interface/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: TTY Error Hint
+The system SHALL provide a helpful hint when the interactive wizard fails due to TTY unavailability.
+
+#### Scenario: TTY unavailable error shows hint
+- WHEN a user runs `spectr init` in an environment without a TTY (CI, Docker, piped input)
+- AND the Bubbletea TUI fails with a TTY-related error
+- THEN the error message SHALL include the original error
+- AND the error message SHALL suggest using `--non-interactive` flag
+- AND the error message SHALL provide an example command: `spectr init --non-interactive --tools <tool1,tool2>`
+
+#### Scenario: Non-TTY errors remain unchanged
+- WHEN the interactive wizard fails for reasons unrelated to TTY access
+- THEN the original error message SHALL be displayed without modification

--- a/spectr/changes/add-tty-error-hint/tasks.md
+++ b/spectr/changes/add-tty-error-hint/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+
+- [ ] 1.1 Create TTY error detection helper in `internal/specterrs/initialize.go`
+- [ ] 1.2 Update `cmd/init.go` to detect TTY errors and enhance with hint
+- [ ] 1.3 Add unit test for TTY error hint in `cmd/init_test.go`
+- [ ] 1.4 Validate change with `spectr validate add-tty-error-hint`


### PR DESCRIPTION
## Summary

Proposal for review: `add-tty-error-hint`

**Location**: `spectr/changes/add-tty-error-hint/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added specifications for improved error messaging when TTY is unavailable during initialization. Users will now receive helpful guidance to use the `--non-interactive` flag along with example commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->