### PR TITLE
fix: remove null frontmatter values from slash command templates

### DIFF
--- a/internal/domain/templates/slash-apply.md.tmpl
+++ b/internal/domain/templates/slash-apply.md.tmpl
@@ -1,8 +1,6 @@
 ---
 description: Change Proposal Application/Acceptance Process (project)
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash(spectr:*)
-agent: null
-model: null
 subtask: false
 ---
 

--- a/internal/domain/templates/slash-proposal.md.tmpl
+++ b/internal/domain/templates/slash-proposal.md.tmpl
@@ -2,7 +2,6 @@
 description: Proposal Creation Guide (project)
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash(spectr:*)
 agent: plan
-model: null
 subtask: false
 ---
 


### PR DESCRIPTION
## Summary

Removes `null` values for `agent` and `model` fields in markdown slash command frontmatter. These null values cause validation errors in OpenCode while providing no value to Claude Code.

## Changes

- `internal/domain/templates/slash-apply.md.tmpl`: Remove `agent: null` and `model: null`
- `internal/domain/templates/slash-proposal.md.tmpl`: Remove `model: null` (keep `agent: plan`)

## Impact

This enables compatible slash command generation for both Claude Code and OpenCode without validation errors. The change is backward compatible - both tools handle missing optional fields gracefully.

## Test Plan

- [x] Builds without errors: `go build -o spectr`
- [x] Tests pass: `go test ./internal/domain/... ./internal/initialize/...`
- [x] Both template variants verified (markdown and TOML formats have appropriate values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified template configuration by removing unused null fields from template metadata headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->