### PR TITLE
spectr(proposal): add-slash-next-command

### DIFF
--- a/spectr/changes/add-slash-next-command/design.md
+++ b/spectr/changes/add-slash-next-command/design.md
@@ -1,0 +1,143 @@
+# Implementation Design for /spectr:next Command
+
+## Overview
+
+The `/spectr:next` slash command will automate task execution for AI agents working with spectr proposals. It finds the next pending task, executes it, and updates statuses automatically.
+
+## Key Components
+
+### 1. Slash Command Definition
+
+**File**: `internal/domain/slashcmd.go`
+
+Add new enum value:
+```go
+const (
+    SlashProposal SlashCommand = iota
+    SlashApply
+    SlashNext  // NEW: Execute next pending task
+)
+```
+
+Update String() method to include "next".
+
+### 2. Task Discovery Logic
+
+**Responsibilities**:
+- Parse tasks.jsonc (handle both flat version 1 and hierarchical version 2)
+- Follow $ref links to child task files
+- Find first task with status "pending"
+- Return task details: ID, description, section, any children
+
+**Implementation approach**:
+- Reuse existing parsers from `internal/parsers/`
+- Create new `taskdiscovery` package or add to existing `discovery`
+- Handle circular reference detection
+- Support both flat and hierarchical task schemas
+
+### 3. Task Execution Engine
+
+**Responsibilities**:
+- Map task descriptions to actions
+- Support common task types:
+  - Code implementation (single file changes)
+  - Test execution
+  - Documentation updates
+  - File creation
+  - Validation tasks
+- Provide extensibility for custom task types
+
+**Simple Version 1 approach**:
+- Parse task description for keywords
+- Use heuristics to determine action type
+- For unknown tasks, provide clear instructions to AI agent
+- Delegate actual implementation to specialized sub-agents
+
+### 4. Status Management
+
+**Responsibilities**:
+- Update task status: pending → in_progress before execution
+- Update task status: in_progress → completed after execution
+- Handle failures gracefully (in_progress → pending on error)
+- Save updated tasks.jsonc atomically
+
+**Implementation**:
+- Reuse existing task sync logic from `internal/sync/`
+- Ensure atomic writes with proper error handling
+- Support both hierarchical and flat file structures
+
+### 5. Provider Template Updates
+
+**Files to update**:
+- `internal/initialize/templates.go` - add SlashNext template
+- All provider files in `internal/initialize/providers/` - add SlashNext to command maps
+
+**Template structure**:
+- Include discovery logic
+- Include execution engine
+- Include status management
+- Provide clear instructions for AI agent
+
+## Implementation Sequence
+
+1. **Core domain changes**:
+   - Add SlashNext to domain.SlashCommand
+   - Update all provider maps to include SlashNext
+
+2. **Task discovery**:
+   - Create task discovery package
+   - Implement tasks.jsonc parsing with $ref support
+   - Test with both v1 and v2 schemas
+
+3. **Template creation**:
+   - Create SlashNext template in templates.go
+   - Include basic task execution patterns
+   - Add status management logic
+
+4. **Provider updates**:
+   - Update all 15+ provider initializers
+   - Generate slash command files
+
+5. **Testing**:
+   - Unit tests for task discovery
+   - Integration tests with sample proposals
+   - Test with hierarchical task files
+
+## Design Decisions
+
+### Heuristic-based vs. Explicit Task Types
+
+**Chosen**: Heuristic-based approach for simplicity
+- Parse task description keywords ("Implement", "Test", "Update", "Create")
+- Map to common actions
+- Provide fallback for unknown tasks
+
+**Alternative considered**: Explicit task types in schema
+- Add "type" field to tasks.jsonc
+- More precise but requires spec changes
+- Can be added later if needed
+
+### Single Command vs. Multi-Step
+
+**Chosen**: Single `/spectr:next` command
+- Simple interface for AI agents
+- Automatically handles discovery → execution → status update
+
+**Alternative**: Separate commands (`/spectr:discover`, `/spectr:execute`, `/spectr:complete`)
+- More flexible but more complex
+- Requires agent to manage state
+
+### Template Implementation Language
+
+**Chosen**: Keep templates in Go with shell commands
+- Consistent with existing slash commands
+- AI agents can read and understand the logic
+- Easy to extend and customize per provider
+
+## Future Extensions
+
+1. **Task Type Registry**: Explicit task types with custom handlers
+2. **Progress Reporting**: Detailed execution logs and metrics
+3. **Parallel Execution**: Run independent tasks concurrently
+4. **Dependency Resolution**: Honor task dependencies before execution
+5. **Custom Task Handlers**: Allow projects to define their own task executors

--- a/spectr/changes/add-slash-next-command/proposal.md
+++ b/spectr/changes/add-slash-next-command/proposal.md
@@ -1,0 +1,94 @@
+# Change: Add /spectr:next Slash Command for Task Execution
+
+## Why
+
+AI agents working with spectr proposals currently need to manually:
+1. Read tasks.jsonc to find the next pending task
+2. Understand the task requirements
+3. Execute the task manually
+4. Update the task status
+
+This creates friction and requires agents to implement task iteration logic themselves. By providing a `/spectr:next` slash command that automatically executes the next pending task in the current change proposal, we streamline the agent workflow and ensure consistent task execution order.
+
+## What Changes
+
+- **ADDED**: New `SlashNext` constant to `domain.SlashCommand` enum
+- **ADDED**: `/spectr:next` slash command template that:
+  - Discovers the current change proposal directory
+  - Parses tasks.jsonc to find the first pending task
+  - Reads the task description and requirements
+  - Executes the appropriate action based on task type
+  - Updates task status from pending → in_progress → completed
+- **MODIFIED**: `domain/slashcmd.go` - add SlashNext to enum
+- **MODIFIED**: All provider initializers to include SlashNext command
+- **MODIFIED**: Slash command templates to support the new command
+
+## Impact
+
+- **Affected specs**: `provider-system`
+- **Affected code**:
+  - `internal/domain/slashcmd.go` - add SlashNext enum value
+  - `internal/initialize/providers/` - update all provider initializers
+  - `internal/initialize/templates.go` - add SlashNext template
+- **Breaking changes**: None - purely additive
+- **New functionality**: AI agents can now use `/spectr:next` to automatically work through task lists
+
+## Examples
+
+### Before (manual task execution)
+
+```
+Human: Work on the add-feature-x proposal
+
+AI Agent:
+1. Read spectr/changes/add-feature-x/tasks.jsonc
+2. Find first pending task (task #3)
+3. Understand task requirements
+4. Manually execute task
+5. Update tasks.jsonc status
+6. Report completion
+```
+
+### After (automated with /spectr:next)
+
+```
+Human: /spectr:next add-feature-x
+
+AI Agent:
+- Automatically executes next pending task
+- Updates status automatically
+- Reports progress without manual intervention
+```
+
+### Slash Command File Structure
+
+```
+.claude/commands/spectr/
+├── proposal.md    # Create new proposal
+├── apply.md       # Apply a change
+└── next.md        # Execute next task [NEW]
+```
+
+### Command Behavior
+
+The `/spectr:next` command will:
+1. Find the current change directory in spectr/changes/
+2. Read tasks.jsonc (following $ref links if hierarchical)
+3. Locate the first task with status "pending"
+4. Execute the task based on its description
+5. Update status: pending → in_progress before execution
+6. Update status: in_progress → completed after execution
+7. Report what was done and what's next
+
+### Example Task Execution Flow
+
+```
+User: /spectr:next
+
+AI Agent:
+→ Found next pending task: #5 "Update API documentation"
+→ Marked task #5 as in_progress
+→ Updating API documentation...
+→ Completed task #5
+→ Next task: #6 "Run tests and fix any failures"
+```

--- a/spectr/changes/add-slash-next-command/specs/slash-commands/spec.md
+++ b/spectr/changes/add-slash-next-command/specs/slash-commands/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: SlashNext Command Support
+The system SHALL support a `SlashNext` command identifier for the `/spectr:next` slash command.
+
+#### Scenario: SlashNext is defined in enum
+- GIVEN the domain.SlashCommand type
+- WHEN examining the available constants
+- THEN SlashNext SHALL be present with a unique value
+- AND SlashNext.String() SHALL return "next"
+
+#### Scenario: SlashNext is distinct from existing commands
+- GIVEN existing SlashCommand values (SlashProposal, SlashApply)
+- WHEN SlashNext is added
+- THEN it SHALL have a different integer value
+- AND it SHALL not conflict with existing command behavior
+
+### Requirement: Provider SlashNext Integration
+All AI assistant provider initializers SHALL include SlashNext in their slash command maps.
+
+#### Scenario: Claude provider includes SlashNext
+- GIVEN the Claude provider initializer
+- WHEN constructing command maps
+- THEN SlashNext SHALL be mapped to the appropriate template
+
+#### Scenario: Other providers include SlashNext
+- GIVEN any provider initializer (Windsurf, Cursor, Continue, etc.)
+- WHEN constructing command maps
+- THEN SlashNext SHALL be present in their command maps
+
+### Requirement: SlashNext Template Definition
+The system SHALL provide a template for the `/spectr:next` slash command that enables AI agents to execute the next pending task.
+
+#### Scenario: Template includes task discovery logic
+- GIVEN a SlashNext template
+- WHEN rendered and executed
+- THEN it SHALL discover the current change proposal
+- AND it SHALL parse tasks.jsonc to find pending tasks
+
+#### Scenario: Template includes status management
+- GIVEN the SlashNext template execution
+- WHEN beginning task execution
+- THEN it SHALL update task status from "pending" to "in_progress"
+- AND upon completion, it SHALL update from "in_progress" to "completed"
+
+#### Scenario: Template handles hierarchical tasks
+- GIVEN a slash command with hierarchical tasks (version 2 schema)
+- WHEN discovering the next task
+- THEN it SHALL follow $ref links to child task files
+- AND it SHALL search for the first pending task recursively
+
+#### Scenario: Template provides execution guidance
+- GIVEN a discovered pending task
+- WHEN executing the SlashNext command
+- THEN the AI agent SHALL receive clear instructions on what action to take
+- AND it SHALL understand the expected outcome
+
+### Requirement: SlashNext Command Generation
+The system SHALL generate `/spectr:next` command files during provider initialization.
+
+#### Scenario: SlashNext file is created
+- GIVEN a provider with SlashNext in its command map
+- WHEN the provider initializer runs
+- THEN a file named "next.md" (or prefixed variant) SHALL be created
+- AND it SHALL contain executable instructions for the AI agent
+
+#### Scenario: SlashNext file includes proposal context
+- GIVEN a SlashNext command file
+- WHEN examining its contents
+- THEN it SHALL include context about spectr task workflow
+- AND it SHALL explain the purpose of the next command
+
+### Requirement: Flat Task File Compatibility
+The SlashNext command SHALL support version 1 flat task files without $ref links.
+
+#### Scenario: Flat tasks.jsonc processing
+- GIVEN a proposal with version 1 tasks.jsonc (no children, no includes)
+- WHEN executing SlashNext
+- THEN it SHALL find the first pending task by sequential scan
+- AND update the flat file structure correctly
+
+### Requirement: Hierarchical Task File Compatibility
+The SlashNext command SHALL support version 2 hierarchical task files with $ref links.
+
+#### Scenario: Hierarchical task discovery
+- GIVEN a proposal with version 2 tasks.jsonc (with children and includes)
+- WHEN discovering the next task
+- THEN it SHALL resolve $ref references to child files
+- AND find the first pending task across the hierarchy
+
+#### Scenario: Parent task status aggregation
+- GIVEN hierarchical tasks with child task statuses
+- WHEN all children of a parent task are completed
+- THEN the parent task status SHALL be automatically updated to "completed"
+
+### Requirement: Error Handling
+The SlashNext command SHALL handle errors gracefully and provide clear feedback.
+
+#### Scenario: No pending tasks
+- GIVEN a proposal where all tasks are completed
+- WHEN executing SlashNext
+- THEN it SHALL report "No pending tasks found"
+- AND provide a summary of completed work
+
+#### Scenario: Invalid task file
+- GIVEN a malformed tasks.jsonc file
+- WHEN attempting to discover tasks
+- THEN it SHALL report the parse error clearly
+- AND suggest running `spectr validate`
+
+#### Scenario: Missing referenced file
+- GIVEN hierarchical tasks with a $ref to a missing file
+- WHEN resolving references
+- THEN it SHALL report the missing file
+- AND provide the expected file path
+
+### Requirement: Execution Reporting
+The SlashNext command SHALL report what task was executed and what comes next.
+
+#### Scenario: Successful task execution
+- GIVEN a task was successfully executed
+- WHEN SlashNext completes
+- THEN it SHALL report:
+  * The task ID and description that was executed
+  * The new status (completed)
+  * The next pending task (if any)
+  * Progress summary (e.g., "3 of 7 tasks completed")
+
+#### Scenario: Task execution failure
+- GIVEN a task execution failed
+- WHEN the failure occurs
+- THEN it SHALL report the error
+- AND update status from "in_progress" back to "pending"
+- AND provide guidance on how to proceed

--- a/spectr/changes/add-slash-next-command/tasks.md
+++ b/spectr/changes/add-slash-next-command/tasks.md
@@ -1,0 +1,106 @@
+# Implementation Tasks
+
+Complete the implementation of the `/spectr:next` slash command for automated task execution.
+
+## 1. Core Domain Changes
+
+- [ ] 1.1 Add `SlashNext SlashCommand = iota` to `internal/domain/slashcmd.go`
+- [ ] 1.2 Update String() method to return "next" for SlashNext
+- [ ] 1.3 Ensure SlashNext has unique value distinct from SlashProposal and SlashApply
+- [ ] 1.4 Run domain tests: `go test ./internal/domain/...`
+
+## 2. Task Discovery Implementation
+
+- [ ] 2.1 Create `internal/discovery/task_discovery.go`
+- [ ] 2.2 Implement `FindNextPendingTask(changeDir string) (*Task, error)`
+- [ ] 2.3 Add support for parsing v1 flat tasks.jsonc files
+- [ ] 2.4 Add support for v2 hierarchical files with $ref links
+- [ ] 2.5 Implement $ref resolution to follow child task files
+- [ ] 2.6 Add circular reference detection
+- [ ] 2.7 Create comprehensive tests with sample task files
+
+## 3. Status Management Implementation
+
+- [ ] 3.1 Create `internal/taskexec/status.go`
+- [ ] 3.2 Implement `UpdateTaskStatus(changeDir string, taskID string, status string) error`
+- [ ] 3.3 Handle both flat v1 and hierarchical v2 file structures
+- [ ] 3.4 Ensure atomic writes to tasks.jsonc files
+- [ ] 3.5 Implement parent task status aggregation logic
+- [ ] 3.6 Add tests for status updates with various task structures
+
+## 4. Template System Updates
+
+- [ ] 4.1 Add `SlashNext()` method to TemplateManager in `internal/initialize/templates.go`
+- [ ] 4.2 Create SlashNext template file in `internal/initialize/templates/`
+- [ ] 4.3 Include task discovery logic in template
+- [ ] 4.4 Include status management workflow
+- [ ] 4.5 Add execution reporting format
+- [ ] 4.6 Include error handling and recovery guidance
+
+## 5. Provider Integration - Claude Ecosystem
+
+- [ ] 5.1 Update `internal/initialize/providers/claude.go` with SlashNext
+- [ ] 5.2 Update `internal/initialize/providers/claude_code.go` with SlashNext
+- [ ] 5.3 Update `internal/initialize/providers/cursor.go` with SlashNext
+- [ ] 5.4 Update `internal/initialize/providers/codex.go` with SlashNext
+- [ ] 5.5 Test `spectr init` generates next.md for each provider
+
+## 6. Provider Integration - Other Providers (Batch 1)
+
+- [ ] 6.1 Update `internal/initialize/providers/continue.go` with SlashNext
+- [ ] 6.2 Update `internal/initialize/providers/cline.go` with SlashNext
+- [ ] 6.3 Update `internal/initialize/providers/kimi.go` with SlashNext
+- [ ] 6.4 Update `internal/initialize/providers/windsurf.go` with SlashNext
+- [ ] 6.5 Update `internal/initialize/providers/qoder.go` with SlashNext
+- [ ] 6.6 Update `internal/initialize/providers/qwen.go` with SlashNext
+
+## 7. Provider Integration - Other Providers (Batch 2)
+
+- [ ] 7.1 Update `internal/initialize/providers/gemini.go` with SlashNext
+- [ ] 7.2 Update `internal/initialize/providers/aider.go` with SlashNext
+- [ ] 7.3 Update `internal/initialize/providers/opencode.go` with SlashNext
+- [ ] 7.4 Update `internal/initialize/providers/costrict.go` with SlashNext
+- [ ] 7.5 Update `internal/initialize/providers/crush.go` with SlashNext
+- [ ] 7.6 Update `internal/initialize/providers/antigravity.go` with SlashNext
+- [ ] 7.7 Update `internal/initialize/providers/kilocode.go` with SlashNext
+
+## 8. Integration Testing
+
+- [ ] 8.1 Create test proposal with v1 flat tasks.jsonc
+- [ ] 8.2 Execute SlashNext and verify correct task discovery
+- [ ] 8.3 Verify status updates from pending → in_progress → completed
+- [ ] 8.4 Create test proposal with v2 hierarchical tasks.jsonc
+- [ ] 8.5 Test $ref resolution to child task files
+- [ ] 8.6 Verify parent task status aggregation when children complete
+
+## 9. Error Handling Tests
+
+- [ ] 9.1 Test with all tasks completed (no pending tasks)
+- [ ] 9.2 Test with malformed tasks.jsonc
+- [ ] 9.3 Test with missing $ref child files
+- [ ] 9.4 Verify clear error messages in each scenario
+- [ ] 9.5 Verify graceful recovery and status rollback on error
+
+## 10. Documentation and Validation
+
+- [ ] 10.1 Run `spectr validate add-slash-next-command`
+- [ ] 10.2 Fix any spec validation errors
+- [ ] 10.3 Update provider system spec documentation
+- [ ] 10.4 Create usage examples with sample proposals
+- [ ] 10.5 Document SlashNext behavior in AGENTS.md
+
+## 11. Final Integration
+
+- [ ] 11.1 Run full test suite: `go test ./...`
+- [ ] 11.2 Test `spectr init` in fresh project
+- [ ] 11.3 Verify next.md generated for multiple providers
+- [ ] 11.4 Review generated command files for accuracy
+- [ ] 11.5 Create demo video/GIF of SlashNext usage
+
+## 12. Cleanup and Archive
+
+- [ ] 12.1 Commit all changes with clear messages
+- [ ] 12.2 Create PR following spectr workflow
+- [ ] 12.3 Include test results in PR description
+- [ ] 12.4 Add screenshots of generated slash command files
+- [ ] 12.5 Run `spectr pr archive add-slash-next-command` on completion


### PR DESCRIPTION
Fixes #354

## Summary

Proposal for review: `add-slash-next-command`

**Location**: `spectr/changes/add-slash-next-command/`

## Files

- `proposal.md` - Change overview
- `tasks.md` - Implementation checklist
- `specs/` - Delta specifications

## Review Checklist

- [ ] Proposal addresses the stated problem
- [ ] Delta specs are properly formatted
- [ ] Tasks are clear and actionable

---
*Generated by `spectr pr proposal`*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/spectr:next` slash command that automatically executes the next pending task within change proposals
  * Adds intelligent task discovery and status management with automatic transitions (pending → in_progress → completed)
  * Includes comprehensive error handling with user feedback for missing tasks and invalid files
  * Provides execution reporting with task details, status updates, and progress summaries

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
